### PR TITLE
Quote default values for string settings in reStructuredText output so that empty strings are clearer.

### DIFF
--- a/config/src/main/java/io/confluent/common/config/ConfigDef.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigDef.java
@@ -544,7 +544,13 @@ public class ConfigDef {
       b.append("\n");
       if (def.defaultValue != null) {
         b.append("  * Default: ");
-        b.append(def.defaultValue);
+        if (def.type == Type.STRING) {
+          b.append("\"");
+          b.append(def.defaultValue);
+          b.append("\"");
+        } else {
+          b.append(def.defaultValue);
+        }
         b.append("\n");
       }
       b.append("  * Importance: ");


### PR DESCRIPTION
Per some confusion in confluentinc/kafka-rest#39, if we add quotes around default string values, it'll be clearer when the default value is empty. Otherwise it just looks like we forgot to fill in that line.
