### PR TITLE
use basepath in maven-assembly-plugin config

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -64,7 +64,7 @@
                         </goals>
                         <configuration>
                             <descriptors>
-                                <descriptor>package/src/assembly/package.xml</descriptor>
+                                <descriptor>${basedir}/src/assembly/package.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>


### PR DESCRIPTION
fixes usage of Maven in another working directory

The following assumes you are in parent directory

Before:
```
$ mvn -DskipTests -f common package

...
[INFO] package ............................................ FAILURE [  0.259 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.068 s
[INFO] Finished at: 2016-08-31T18:22:28-05:00
[INFO] Final Memory: 15M/360M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.5.2:single (package-assembly) on project common-package: Error reading assemblies: Error locating assembly descriptor: package/src/assembly/package.xml
[ERROR] 
[ERROR] [1] [INFO] Searching for file location: /home/brandon/build/common/package/package/src/assembly/package.xml
[ERROR] 
[ERROR] [2] [INFO] File: /home/brandon/build/common/package/package/src/assembly/package.xml does not exist.
[ERROR] 
[ERROR] [3] [INFO] File: /home/brandon/build/package/src/assembly/package.xml does not exist.
```

This patch makes the command above successful.