### PR TITLE
CPKAFKA-437: Make ConfigUtils#translateDeprecated robust against non-string Properties values

### DIFF
--- a/config/src/main/java/io/confluent/common/config/ConfigUtils.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigUtils.java
@@ -59,8 +59,9 @@ public class ConfigUtils {
     for (Enumeration<String> keyEnumerator = (Enumeration<String>) props.propertyNames();
          keyEnumerator.hasMoreElements(); ) {
       String key = keyEnumerator.nextElement();
-      if (!synonymSet.contains(key))
-        newProps.setProperty(key, props.getProperty(key));
+      if (!synonymSet.contains(key)) {
+        newProps.put(key, props.get(key));
+      }
     }
     // Process each synonym group.
     for (String[] synonymGroup: synonymGroups) {
@@ -83,17 +84,17 @@ public class ConfigUtils {
         // Ignore the deprecated key(s) because the actual key was set.
         log.error(target + " was configured, as well as the deprecated synonym(s) " +
           synonymString + ".  Using the value of " + target);
-        newProps.setProperty(target, props.getProperty(target));
+        newProps.put(target, props.get(target));
       } else if (deprecated.size() > 1) {
         log.error("The configuration keys " + synonymString + " are deprecated and may be " +
           "removed in the future.  Additionally, this configuration is ambigous because " +
           "these configuration keys are all synonyms for " + target + ".  Please update " +
           "your configuration to have only " + target + " set.");
-        newProps.setProperty(target, props.getProperty(deprecated.get(0)));
+        newProps.put(target, props.get(deprecated.get(0)));
       } else {
         log.warn("Configuration key " + deprecated.get(0) + " is deprecated and may be removed " +
           "in the future.  Please update your configuration to use " + target + " instead.");
-        newProps.setProperty(target, props.getProperty(deprecated.get(0)));
+        newProps.put(target, props.get(deprecated.get(0)));
       }
     }
     return newProps;

--- a/config/src/test/java/io/confluent/common/config/ConfigUtilsTest.java
+++ b/config/src/test/java/io/confluent/common/config/ConfigUtilsTest.java
@@ -33,6 +33,7 @@ public class ConfigUtilsTest {
     props.setProperty("hen", "3");
     props.setProperty("heifer", "moo");
     props.setProperty("blah", "blah");
+    props.put("unexpected.non.string.object", new Integer(42));
     Properties newProps = ConfigUtils.translateDeprecated(props, new String[][]{
         { "foo.bar", "foo.bar.deprecated" },
         { "chicken", "rooster", "hen" },
@@ -50,5 +51,15 @@ public class ConfigUtilsTest {
     assertEquals(null, props.getProperty("cow"));
     assertEquals("blah", props.getProperty("blah"));
     assertEquals("blah", newProps.getProperty("blah"));
+
+    // The java.util.Properties class was intended to store only String values.
+    // However, because of a design mistake, it can actually store arbitrary Objects.
+    // They are not returned when Properties#getProperty is invoked, but they are
+    // returned when Properties#get is invoked.
+    // Here, we test that ConfigUtils passes through these objects unchanged.
+    assertEquals(null, newProps.getProperty("unexpected.non.string.object"));
+    assertEquals(new Integer(42), newProps.get("unexpected.non.string.object"));
+    assertEquals(null, props.getProperty("unexpected.non.string.object"));
+    assertEquals(new Integer(42), props.get("unexpected.non.string.object"));
   }
 }


### PR DESCRIPTION
The java.util.Properties class was intended to store only String values.  However, because of a design mistake, it can actually store arbitrary Objects.  They are not returned when Properties#getProperty is invoked, but they are returned when Properties#get is invoked.

Formerly, these values would cause a bug in ConfigUtils#translateDeprecated, because they would appear in the key enumeration, but getProperties would return null for them.  This bug is fixed by calling get() instead of getProperty().