### PR TITLE
different executions of unit and integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,27 @@
                 <configuration>
                     <argLine>@{argLine} -Djava.awt.headless=true</argLine>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>io.confluent.common.utils.IntegrationTest</groups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Use junit categories to separate unit from integration tests. Configured executions of the sure-fire plugin.