### PR TITLE
Integration test pom fixins

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>common</artifactId>
+        <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
         <version>3.3.0-SNAPSHOT</version>
     </parent>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.confluent</groupId>
-        <artifactId>common</artifactId>
+        <artifactId>common-parent</artifactId>
         <version>3.3.0-SNAPSHOT</version>
     </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--~
-  ~ Copyright 2015 Confluent Inc.
+  ~ Copyright 2017 Confluent Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -13,11 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~-->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -26,23 +25,14 @@
         <version>3.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>common-config</artifactId>
-    <packaging>jar</packaging>
-    <name>config</name>
+    <artifactId>common</artifactId>
+    <packaging>pom</packaging>
+    <name>Common</name>
 
     <dependencies>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,27 @@
                 <configuration>
                     <argLine>@{argLine} -Djava.awt.headless=true</argLine>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>io.confluent.common.utils.IntegrationTest</groups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.confluent</groupId>
-    <artifactId>common</artifactId>
+    <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
     <version>3.3.0-SNAPSHOT</version>
     <name>common</name>
@@ -81,6 +81,7 @@
         <module>config</module>
         <module>utils</module>
         <module>package</module>
+        <module>parent</module>
     </modules>
 
     <dependencyManagement>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>common</artifactId>
+        <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
         <version>3.3.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
this does a couple things
1. renames current common parent/module pom to `common-parent`
2. creates a replacement parent with the old name for downstream deps to use (this is the `parent` module)
3. re-add the integration test configs to `common-parent`

