### PR TITLE
Remove ClassFanOutComplexity check

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -218,7 +218,6 @@
         </module>
         <module name="ClassDataAbstractionCoupling"/>
         <module name="BooleanExpressionComplexity"/>
-        <module name="ClassFanOutComplexity"/>
         <module name="CyclomaticComplexity"/>
         <module name="JavaNCSS" />
         <module name="NPathComplexity"/>


### PR DESCRIPTION
As discussed in the `#code-quality` slack channel, this check does more harm than good.

I think this removes the ClassFanOutComplexity check.