### PR TITLE
Add fix for do-while loops with checkstyle

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -69,7 +69,7 @@
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
-            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlyAlone"/>


### PR DESCRIPTION
Do-while loops are handled poorly by the `RightCurly` module when using Checkstyle 6.19; the behavior is corrected in version 7.0+, but we can't switch to that right now as it requires JDK 8+. As a result, this fix can be added in the meantime to avoid false negatives on correctly-formatted do-while loops. As a further plus, it should also allow suppressions like [this](https://github.com/confluentinc/blueway/blob/15b4632e1b4321cf6cb9938f54af388a882eab36/checkstyle/suppressions.xml#L122-L126) to be removed.