### PR TITLE
Use --release instead of --source/--target if compiling with Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <kafka.version>0.11.1.0-SNAPSHOT</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <maven-assembly.version>2.6</maven-assembly.version>
-        <maven-compiler-plugin.version>2.5.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
@@ -324,8 +324,8 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>7</source>
+                    <target>7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -494,6 +494,26 @@
                     </plugin>
                 </plugins>
             </reporting>
+        </profile>
+        <profile>
+            <id>java-9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Use release instead of source/target in Java 9 or higher -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven-compiler-plugin.version}</version>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <release>7</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This allows one to use Java 9 and compile for older releases safely. See: http://openjdk.java.net/jeps/247

`mvn compile` and `mvn test` succeed when running with Java 9, but I saw some exceptions when running `mvn` with debug enabled. We'll probably have to bump the version of a number of plugins for everything to work correctly with Java 9. We can do that in a separate PR though.