### PR TITLE
Checkstyle overrides are needed in reporting config also

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,23 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-checkstyle-plugin</artifactId>
+                      <version>2.17</version>
+                      <dependencies>
+                        <dependency>
+                          <groupId>io.confluent</groupId>
+                          <artifactId>build-tools</artifactId>
+                          <version>${confluent.version}</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>com.puppycrawl.tools</groupId>
+                          <artifactId>checkstyle</artifactId>
+                          <version>6.19</version>
+                        </dependency>
+                      </dependencies>
+                    </plugin>
                 </plugins>
             </build>
             <reporting>
@@ -524,7 +541,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <configuration>
-                            <failsOnError>false</failsOnError>
+                            <configLocation>checkstyle/checkstyle.xml</configLocation>
+                            <suppressionsLocation>checkstyle/common-suppressions.xml</suppressionsLocation>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <failOnViolation>true</failOnViolation>
                             <includeResources>false</includeResources>
                             <includeTestResources>false</includeTestResources>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -546,7 +546,7 @@
                             <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
+                            <failsOnError>false</failsOnError>
                             <failOnViolation>true</failOnViolation>
                             <includeResources>false</includeResources>
                             <includeTestResources>false</includeTestResources>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
         <slf4j.version>1.7.25</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.10</zookeeper.version>
+        <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
+        <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
     </properties>
 
     <scm>
@@ -282,8 +284,8 @@
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.17</version>
                     <configuration>
-                        <configLocation>checkstyle/checkstyle.xml</configLocation>
-                        <suppressionsLocation>checkstyle/common-suppressions.xml</suppressionsLocation>
+                        <configLocation>${checkstyle.config.location}</configLocation>
+                        <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                         <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
@@ -541,8 +543,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <configuration>
-                            <configLocation>checkstyle/checkstyle.xml</configLocation>
-                            <suppressionsLocation>checkstyle/common-suppressions.xml</suppressionsLocation>
+                            <configLocation>${checkstyle.config.location}</configLocation>
+                            <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
                             <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>


### PR DESCRIPTION
If you build site with the jenkins profile, you can see in `site/checkstyle-aggregate.html` that it uses `sun_checks.xml` instead of our own checkstyle config. Not sure if there are better solutions, but overriding the config in the profile seems to work. One crappy thing is that we may need to override the suppressions location for each project separately... Not sure if we can find a way to add `checkstyle/suppressions.xml` to the list of suppressions here.