### PR TITLE
CC-1333: Move avro version variable from schema registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <properties>
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
+        <avro.version>1.8.2</avro.version>
         <confluent.version>3.3.2-SNAPSHOT</confluent.version>
         <easymock.version>3.4</easymock.version>
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>


### PR DESCRIPTION
Move avro version so both schema registry and storage common can use it.

Signed-off-by: Arjun Satish <arjun@confluent.io>