### PR TITLE
CLIENTS-835: Downgrade Avro from 1.8.2 to 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.8.1</avro.version>
         <confluent.version>3.3.2-SNAPSHOT</confluent.version>
         <easymock.version>3.4</easymock.version>
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>


### PR DESCRIPTION
1.8.2 contains a critical bug https://issues.apache.org/jira/browse/AVRO-2122
which customers are encountering. Although a fix is available
https://github.com/apache/avro/pull/276, it isn't merged yet and Avro releases
are very infrequent. The bug is not present in 1.8.1 and of the
fixes/improvements from 1.8.1 to 1.8.2 we are pretty confident 1.8.1 is going
to be the better release to go with.