### PR TITLE
MINOR: Add copy constructor for ConfigDef

### DIFF
--- a/config/src/main/java/io/confluent/common/config/ConfigDef.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigDef.java
@@ -68,7 +68,7 @@ import io.confluent.common.config.types.Password;
  */
 public class ConfigDef {
 
-  private static final Object NO_DEFAULT_VALUE = new Object();
+  protected static final Object NO_DEFAULT_VALUE = new Object();
 
   private final Map<String, ConfigKey> configKeys;
 

--- a/config/src/main/java/io/confluent/common/config/ConfigDef.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigDef.java
@@ -76,8 +76,8 @@ public class ConfigDef {
     configKeys = new HashMap<>();
   }
 
-  public ConfigDef(ConfigDef baseConfigDef) {
-    configKeys = new HashMap<>(baseConfigDef.configKeys);
+  public ConfigDef(ConfigDef configDef) {
+    configKeys = new HashMap<>(configDef.configKeys);
   }
 
   /**

--- a/config/src/main/java/io/confluent/common/config/ConfigDef.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigDef.java
@@ -70,7 +70,15 @@ public class ConfigDef {
 
   private static final Object NO_DEFAULT_VALUE = new Object();
 
-  private final Map<String, ConfigKey> configKeys = new HashMap<String, ConfigKey>();
+  private final Map<String, ConfigKey> configKeys;
+
+  public ConfigDef() {
+    configKeys = new HashMap<>();
+  }
+
+  public ConfigDef(ConfigDef baseConfigDef) {
+    configKeys = new HashMap<>(baseConfigDef.configKeys);
+  }
 
   /**
    * Returns unmodifiable set of properties names defined in this {@linkplain ConfigDef}

--- a/config/src/test/java/io/confluent/common/config/ConfigDefTest.java
+++ b/config/src/test/java/io/confluent/common/config/ConfigDefTest.java
@@ -52,9 +52,38 @@ import static io.confluent.common.config.ConfigDef.Type.LONG;
 import static io.confluent.common.config.ConfigDef.Type.STRING;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 public class ConfigDefTest {
+
+  @Test
+  public void testCopyConstructor() {
+    ConfigDef original = new ConfigDef().define("a", INT, ConfigDef.Importance.LOW, "docs")
+        .define("b", STRING, ConfigDef.Importance.HIGH, "docs");
+
+    ConfigDef copy = new ConfigDef(original);
+
+    Properties props = new Properties();
+    props.put("a", "5");
+    props.put("b", "foo");
+    props.put("c", "true");
+
+    // Ensure the copied ConfigDef contains all the definitions of the original
+    Map<String, Object> originalParsedProps = original.parse(props);
+    Map<String, Object> copyParsedProps = copy.parse(props);
+    assertEquals(originalParsedProps, copyParsedProps);
+    assertFalse(copyParsedProps.containsKey("c"));
+
+    copy.define("c", BOOLEAN, ConfigDef.Importance.MEDIUM, "docs");
+
+    // Ensure that mutating the copied ConfigDef doesn't also mutate the original
+    originalParsedProps = original.parse(props);
+    copyParsedProps = copy.parse(props);
+    assertNotEquals(originalParsedProps, copyParsedProps);
+    assertEquals(true, copyParsedProps.get("c"));
+  }
 
   @Test
   public void testBasicTypes() {


### PR DESCRIPTION
The `ConfigDef` in Kafka already has support for this; adding it to enable subclassing of `ConfigDef` while still playing nicely with our `rest-utils`, specifically the idiom of creating a `ConfigDef` by starting with the `RestConfig.baseConfigDef()` method and chaining `define()` calls from there.