### PR TITLE
Update versions to support spring boot

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,6 +20,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.0.1-ZEFR-1</version>
     <name>Build Tools</name>
 </project>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>4.0.2-SNAPSHOT</version>
+	<version>4.0.1-ZEFR-1</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>4.0.2-SNAPSHOT</version>
+    	<version>4.0.1-ZEFR-1</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,8 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>4.0.2-SNAPSHOT</version>
+	    <version>4.0.1-ZEFR-1</version>
+
     </parent>
 
     <artifactId>common-package</artifactId>
@@ -35,7 +36,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>build-tools</artifactId>
-            <version>4.0.2-SNAPSHOT</version>
+            <version>4.0.1-ZEFR-1</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.1-ZEFR-1</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.0.1-ZEFR-1</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -46,13 +46,13 @@
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
         <avro.version>1.8.1</avro.version>
-        <confluent.version>4.0.2-SNAPSHOT</confluent.version>
+        <confluent.version>4.0.1-ZEFR-1</confluent.version>
         <easymock.version>3.5</easymock.version>
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <jackson.version>2.9.5</jackson.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>
-        <kafka.version>1.0.2-SNAPSHOT</kafka.version>
+        <kafka.version>1.0.1</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <maven-assembly.version>2.6</maven-assembly.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>4.0.2-SNAPSHOT</version>
+        <version>4.0.1-ZEFR-1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
There will be a corresponding pull request on common-docker and another on rest-utils

This is required to utilize the rest-utils for unit tests in a spring boot application

https://github.com/ZEFR-INC/kafka-kstreams-kotlin-example-app

The basic issue is that spring boot requires newer versions of jetty and jersey while confluent is stuck on old versions.  Relatively minor changes are required to make this work, but it does require java 8 per comments (not tested). Considering java 7 has been end of life since April 2015 https://www.java.com/en/download/faq/java_7.xml I think this is reasonable.

Please feel free to fork the kotlin example app to include as a sample kstream app for kotlin. It's only non-public dependency is some compiled avro files that could be easily switched to some other avro files.

