### PR TITLE
Update Slack Channel subscription to reflect current project ownership

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 common {
-  slackChannel = '#clients-eng'
+  slackChannel = '#kafka-core-eng'
   // This is not strictly required in this repo, but is easiest here so we only maintain this Kafka upstream trigger in one
   // place to trigger the rest of the pipeline. Note that we need to maintain the references to the jobs carefully since they
   // change across version branches.


### PR DESCRIPTION
Changed to reflect the outcome of the conversation here:

confluentinc/confluent-security-plugins#61

common -> core
rest-utils -> C3
confluent-security-plugins -> connect

merging into 3.3.x so it can be pushed upward with pint