### PR TITLE
CC-1975: Increase PermGen for surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
-        <maven-surefire-plugin.vmopts>-XX:MaxPermSize=128m</maven-surefire-plugin.vmopts>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
@@ -457,7 +456,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>@{argLine} -Djava.awt.headless=true ${maven-surefire-plugin.vmopts}</argLine>
+                    <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=128m</argLine>
                     <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
                 </configuration>
                 <executions>


### PR DESCRIPTION
This is to help downstream repos which need a larger PermGen for their tests. This will enable us to increase perm gen for kafka-connect-jdbc tests which are failing on Jenkins right now. Related PR: https://github.com/confluentinc/kafka-connect-jdbc/pull/413.

Signed-off-by: Arjun Satish <arjun@confluent.io>