### PR TITLE
Upgrade Avro to 1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
-        <avro.version>1.8.1</avro.version>
+        <avro.version>1.8.2</avro.version>
         <required.maven.version>3.2</required.maven.version>
         <confluent.version>5.0.0-SNAPSHOT</confluent.version>
         <easymock.version>3.5</easymock.version>


### PR DESCRIPTION
Some projects that depend on common are using Avro 1.8.2
already and this causes issues in the tarball
distribution due to multiple versions in the classpath.
Thanks to @maxzheng for diagnosing a system test
failure due to this issue.