### PR TITLE
Add license as upstream and remove kafka

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
 #!/usr/bin/env groovy
-docker_oraclejdk8 {
-    // This is not strictly required in this repo, but is easiest here so we only maintain this Kafka upstream trigger in one
-    // place to trigger the rest of the pipeline. Note that we need to maintain the references to the jobs carefully since they
-    // change across version branches.
-    upstreamProjects = ['kafka-trunk', 'confluentinc/confluent-docker-utils']
+
+dockerfile {
+    upstreamProjects = ['confluentinc/confluent-docker-utils', 'confluentinc/license-file-generator']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     dockerRepos = ['confluentinc/cp-base']
     slackChannel = '#kafka-core-eng'


### PR DESCRIPTION
kafka-trunk is a freestyle job and will not work with upstreamProjects as we append the branch after the job name.

We could fix upstreamProjects to work, but probably better without as having to maintain the branch mapping is not going to happen, which is the case based on current values used. So just drop it until we have better ways to map the branches automatically.

Also change to use dockerfile as docker_oraclejdk8 is deprecated

Replay: https://jenkins.confluent.io/job/confluentinc/job/common/job/4.1.x/151/