### PR TITLE
Set version of maven-site and maven-project-info-reports to ensure compatibility

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,4 +22,17 @@
     <artifactId>build-tools</artifactId>
     <version>3.3.2-SNAPSHOT</version>
     <name>Build Tools</name>
+    <build>
+        <!-- build-tools does not inherit from common
+        so we need to define plugin versions again -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <powermock.version>1.6.6</powermock.version>
@@ -319,6 +321,16 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>${maven-project-info-reports-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -412,7 +424,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
This is a selective backport of the following commit that was merged to
5.0.x and master:

https://github.com/confluentinc/common/commit/d5c973a2c766b61a8ff789dc0768ae005df63209