### PR TITLE
MINOR: Corrected version of Powermock Mockito artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
+                <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
The correct artifact is `org.powermock:powermock-api-mockito2` for version `2.0.0-beta.5`. See the [Maven Central listing](https://search.maven.org/#search%7Cga%7C1%7Cpowermock-api-mockito).