### PR TITLE
MINOR: Disabled dependency location feature of maven-plugin-info-reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,6 +427,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>${maven-project-info-reports-plugin.version}</version>
+                    <configuration>
+                        <!-- 
+                        Disable dependency locations for latest maven-plugin-info-reports to eliminate blacklisting
+                        warnings: "The repository url '...' is invalid - Repository '...' will be blacklisted."
+                        -->
+                        <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We recently pinned the version of the `maven-plugin-info-reports` plugin to 3.7.1, and this resulted in some new warnings about blacklisting repositories. For example:
```
[WARNING] The repository url 'https://nexus.confluent.io/repository/maven-public' is invalid - Repository 'confluent-nexus-central' will be blacklisted.
```
Apparently disabling the dependency locations check will eliminate these warnings.