### PR TITLE
Add FinalParametersCheck as an optional checkstyle check.

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -221,9 +221,9 @@
         <module name="JavaNCSS" />
         <module name="NPathComplexity"/>
 
-        <module name="FinalParametersCheck">
+        <module name="FinalParameters">
             <property name="severity"
-                      value="${checkstyle.finalparameter.severity}"
+                      value="${checkstyle.finalparameters.severity}"
                       default="ignore"/>
         </module>
     </module>

--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -220,5 +220,11 @@
         <module name="CyclomaticComplexity"/>
         <module name="JavaNCSS" />
         <module name="NPathComplexity"/>
+
+        <module name="FinalParametersCheck">
+            <property name="severity"
+                      value="${checkstyle.finalparameter.severity}"
+                      default="ignore"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
Downstream projects can enable the check by setting the severity higher (e.g. warning or error) with the `checkstyle.finalparameter.severity` property using either `propertyExpansion` or `propertiesLocation` settings for the checkstyle plugin (https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-property-expansion.html).