### PR TITLE
Add opt-in rule for Imports ordering rule to match Confluent style guide

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -175,6 +175,19 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="specialImportsRegExp"
+                      value="${checkstyle.customimportorder.specialimportsregexp}"
+                      default="^(com.google|android|antenna|antlr|ar|asposewobfuscated|asquare|atg|au|beaver|bibtex|bmsi|bsh|ccl|cern|ChartDirector|checkers|com|COM|common|contribs|corejava|cryptix|cybervillains|dalvik|danbikel|de|EDU|eg|eu|examples|fat|fit|fitlibrary|fmpp|freemarker|gnu|groovy|groovyjarjarantlr|groovyjarjarasm|hak|hep|ie|imageinfo|info|it|jal|Jama|japa|japacheckers|jas|jasmin|javancss|javanet|javassist|javazoom|java_cup|jcifs|jetty|JFlex|jj2000|jline|jp|JSci|jsr166y|junit|jxl|jxxload_help|kawa|kea|libcore|libsvm|lti|memetic|mt|mx4j|net|netscape|nl|nu|oauth|ognl|opennlp|oracle|org|penn2dg|pennconverter|pl|prefuse|proguard|repackage|scm|se|serp|simple|soot|sqlj|src|ssa|sun|sunlabs|tcl|testdata|testshell|testsuite|twitter4j|uk|ViolinStrings|weka|wet|winstone|woolfel|wowza)\."/>
+            <property name="customImportOrderRules"
+                      value="${checkstyle.customimportorder.customimportorderrules}"
+                      default="SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###STATIC"/>
+            <property name="severity"
+                      value="${checkstyle.customimportorder.severity}"
+                      default="ignore"/>
+        </module>
         <module name="MethodParamPad"/>
         <module name="ParenPad"/>
         <module name="OperatorWrap">


### PR DESCRIPTION
[Out style guide](https://confluentinc.atlassian.net/wiki/spaces/Engineering/pages/5505079/New+Hire+Onboard#NewHireOnboard-CodingStyle) has a specific order of imports.

I'm seeing a lot of PRs with different orders of imports - making the code yo-yo back and forth and making reviews larger than they need to be.

This PR adds the `CustomImportOrder` check to ensure the import order matches our style guide.

The new check is disabled by default, (otherwise it will break downstream projects).

Downstream projects can enable the check by setting the severity higher (e.g. warning or error) with the
checkstyle.customimportorder.severity property using either propertyExpansion or propertiesLocation settings
for the checkstyle plugin. See: https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-property-expansion.html