### PR TITLE
Adds opt-in rule for detecting redundant modifiers

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -220,5 +220,11 @@
         <module name="CyclomaticComplexity"/>
         <module name="JavaNCSS" />
         <module name="NPathComplexity"/>
+
+        <module name="RedundantModifier">
+            <property name="severity"
+                      value="${checkstyle.redundantmodifier.severity}"
+                      default="ignore"/>
+        </module>
     </module>
 </module>


### PR DESCRIPTION
This rule is ignored by default, (otherwise it will break downstream projects).

Downstream projects can enable the check by setting the severity higher (e.g. warning or error) with the
checkstyle.redundantmodifier.severity property using either propertyExpansion or propertiesLocation settings
for the checkstyle plugin. See: https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-property-expansion.html