### PR TITLE
Correct import order from 'EwenStyle' to 'GoogleStyle'

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -180,10 +180,10 @@
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="specialImportsRegExp"
                       value="${checkstyle.customimportorder.specialimportsregexp}"
-                      default="^(com.google|android|antenna|antlr|ar|asposewobfuscated|asquare|atg|au|beaver|bibtex|bmsi|bsh|ccl|cern|ChartDirector|checkers|com|COM|common|contribs|corejava|cryptix|cybervillains|dalvik|danbikel|de|EDU|eg|eu|examples|fat|fit|fitlibrary|fmpp|freemarker|gnu|groovy|groovyjarjarantlr|groovyjarjarasm|hak|hep|ie|imageinfo|info|it|jal|Jama|japa|japacheckers|jas|jasmin|javancss|javanet|javassist|javazoom|java_cup|jcifs|jetty|JFlex|jj2000|jline|jp|JSci|jsr166y|junit|jxl|jxxload_help|kawa|kea|libcore|libsvm|lti|memetic|mt|mx4j|net|netscape|nl|nu|oauth|ognl|opennlp|oracle|org|penn2dg|pennconverter|pl|prefuse|proguard|repackage|scm|se|serp|simple|soot|sqlj|src|ssa|sun|sunlabs|tcl|testdata|testshell|testsuite|twitter4j|uk|ViolinStrings|weka|wet|winstone|woolfel|wowza)\."/>
+                      default=""/>
             <property name="customImportOrderRules"
                       value="${checkstyle.customimportorder.customimportorderrules}"
-                      default="SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###STATIC"/>
+                      default="STATIC###THIRD_PARTY_PACKAGE"/>
             <property name="severity"
                       value="${checkstyle.customimportorder.severity}"
                       default="ignore"/>


### PR DESCRIPTION
Original ImportOrderCheck added was based of Ewen's intelliJ code style file, which was meant to be GoogleStyle, but had some differences.  This PR sets the import order to true Google Style.

Should be OK to change as this was recently added, by me, so I doubt anyone is using this yet.