### PR TITLE
Add ability to suppress checkstyle rules using comments.

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -41,6 +41,19 @@
     </module>
 
     <module name="TreeWalker">
+        <!-- Generic 'turn all checkstyle off' comment filter -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE:OFF"/>
+            <property name="onCommentFormat" value="CHECKSTYLE:ON"/>
+        </module>
+
+        <!-- Specific 'turn list of checkstyle rules off' comment filter -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE_RULES.OFF:\s+([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE_RULES.ON:\s+([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
+
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.13</zookeeper.version>
-        <checkstyle.version>6.19</checkstyle.version>
+        <checkstyle.version>8.5</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>


### PR DESCRIPTION
This, in general, works better with IDEs that a suppression file, and puts the suppression with the code.

E.g. to suppress a one or more rules:

```
// CHECKSTYLE_RULES.OFF:  ClassDataAbstractionCouplingCheck|CyclomaticComplexityCheck - This class is complex because blah blah blah
public class SomeJustifiablyComplexClass {
 ...
}
// CHECKSTYLE_RULES.ON:  ClassDataAbstractionCouplingCheck|CyclomaticComplexityCheck
```

E.g. to turn of checkstyle all together:

```
// CHECKSTYLE:OFF - Checkstyle is turned off because this code is generated by blah.
... some generated code.
// CHECKSTYLE:ON
```