### PR TITLE
slf4j-log4j12 in test scope causes downstream issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,6 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Having sl4fj-log4j12 as an explicit test-scoped dependency causes subtle
issues for downstream projects that use common-pom as a parent.

Projects that need log output during test runs, should either explicitly
declare a dependency on slf4j-log4j12 (either test or runtime scoped,
depending on whether that project should ship a logging implementation).

Bear with me, but here's an example of what can happen:
- project A uses common-parent and has sl4fj-log4j12 as a runtime dependency
- project B also uses common-parent and has project A as dependency

You would expect that project B would now also have slf4j-log4j12 as a
runtime dependency. Except, because common-parent has an explicit
depenency in test-scope, this now overrides the scope defined in A.
As a result, project B now doesn't produce any logs.

This means any project using common-parent that needs a logging
implementation, also has to specifically redefine a runtime scope
dependency on sl4fj-log4j12 to override the common pom, even if that
runtime dependency should have been pulled in transitively.

This change now requires projects to explicitly declare a test-scope
dependency on a slf4j logging implementation if they need
logging output during testing but don't want to ship a logging
implementation.

One alternative I see to this change would be to declare a common
test-scoped dependency on slf4j-simple, so tests still produce logs
without conflicting with any logging implementation we might want to
ship (assuming of course we never want to ship slf4j-simple)