### PR TITLE
Bump AK to 1.1.1-cp1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <jackson.version>2.9.6</jackson.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>
-        <kafka.version>1.1.1-SNAPSHOT</kafka.version>
+        <kafka.version>1.1.1-cp1</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <licenses.version>${project.version}</licenses.version>
         <maven-assembly.version>3.0.0</maven-assembly.version>


### PR DESCRIPTION
Bump AK to 1.1.1-cp1
* AK 1.1.1-snapshot doesnt exists in the repo.

Currently,  kafka-1.1/ packaging-4.1.x are failing due to this.