### PR TITLE
Re-introduce spotbugs versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <confluent.version>5.1.0-SNAPSHOT</confluent.version>
         <easymock.version>3.6</easymock.version>
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
+        <findbugs-annotations.version>3.0.1</findbugs-annotations.version>
         <spotbugs.version>3.1.7</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.6</spotbugs.maven.plugin.version>
         <java.version>8</java.version>


### PR DESCRIPTION
KSQL is still dependent on spotbugs and currently cannot build since it cannot find the version