### PR TITLE
Upgrade checkstyle and maven compiler plugin, enforce consistent EOF line endings

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -35,6 +35,8 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="NewlineAtEndOfFile" />
+
     <!-- header -->
     <module name="RegexpHeader">
         <property name="header" value="/\*\nCopyright .* Confluent Inc."/>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <kafka.scala.version>2.11</kafka.scala.version>
         <licenses.version>${project.version}</licenses.version>
         <maven-assembly.version>3.0.0</maven-assembly.version>
-        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
         <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.13</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
-        <checkstyle.version>8.5</checkstyle.version>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
+        <checkstyle.version>8.13</checkstyle.version>
+        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
@@ -351,7 +351,7 @@
                     <configuration>
                         <configLocation>${checkstyle.config.location}</configLocation>
                         <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
-                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
                         <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
@@ -651,7 +651,7 @@
                         <configuration>
                             <configLocation>${checkstyle.config.location}</configLocation>
                             <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
-                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                            <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>false</failsOnError>


### PR DESCRIPTION
* Upgrade checkstyle and maven checkstyle plugin to latest versions
* Upgrade maven compiler plugin to support Java 10
* Enforce consistent newlines at end of files