### PR TITLE
Revert to SpotBugs 3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,9 @@
         <confluent.version>5.1.0-SNAPSHOT</confluent.version>
         <easymock.version>3.6</easymock.version>
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-        <spotbugs.version>3.1.7</spotbugs.version>
-        <spotbugs.maven.plugin.version>3.1.6</spotbugs.maven.plugin.version>
+        <!-- 3.1.6 has a regression that breaks when processing Kafka code, seems to be https://github.com/spotbugs/spotbugs/pull/688, verify that Muckrake works if bumping this -->
+        <spotbugs.version>3.1.5</spotbugs.version>
+        <spotbugs.maven.plugin.version>3.1.7</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.9.6</jackson.version>
         <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>


### PR DESCRIPTION
Newer versions break when processing Kafka code. A couple of examples:

```text
Error processing opcode checkcast @ 63 in kafka.security.auth.SimpleAclAuthorizer.logMessage$1 : (Lorg.apache.kafka.common.security.auth.KafkaPrincipal;ZLkafka.security.auth.Operation;Lkafka.security.auth.Resource;Ljava.lang.String;)Ljava.lang.String;
```

```text
Error processing opcode checkcast @ 31 in kafka.cluster.Broker.toString : ()Ljava.lang.String;
  java.lang.IllegalArgumentException: Unknown signature [Ljava/lang/Object; for number 4
    At edu.umd.cs.findbugs.OpcodeStack$Item.<init>(OpcodeStack.java:671)```