### PR TITLE
Move logging libs under logging group

### DIFF
--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -31,6 +31,7 @@
     </properties>
 
     <artifactId>confluent-log4j-extensions</artifactId>
+    <groupId>io.confluent.logging</groupId>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -40,7 +41,7 @@
             <version>1.2.17</version>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
+            <groupId>io.confluent.logging</groupId>
             <artifactId>common-logging</artifactId>
             <version>${confluent.version}</version>
         </dependency>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -31,6 +31,7 @@
     </properties>
 
     <artifactId>confluent-log4j2-extensions</artifactId>
+    <groupId>io.confluent.logging</groupId>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -40,7 +41,7 @@
             <version>2.11.1</version>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
+            <groupId>io.confluent.logging</groupId>
             <artifactId>common-logging</artifactId>
             <version>${confluent.version}</version>
         </dependency>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -31,6 +31,7 @@
     </properties>
 
     <artifactId>common-logging</artifactId>
+    <groupId>io.confluent.logging</groupId>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
This patch moves the logging libs under the group io.confluent.logging.
This way these artifacts don't get sucked up into the common-* wildcard
excludes in downstream packaging assemblies, e.g.:

https://github.com/confluentinc/ksql/blob/1ae1177b820109588413ea01b3f615cca746634e/ksql-package/src/assembly/package.xml#L82