### PR TITLE
deprecate common configs

### DIFF
--- a/config/src/main/java/io/confluent/common/config/AbstractConfig.java
+++ b/config/src/main/java/io/confluent/common/config/AbstractConfig.java
@@ -53,6 +53,7 @@ import io.confluent.common.utils.Utils;
  * A convenient base class for configurations to extend. <p> This class holds both the original
  * configuration that was provided as well as the parsed
  */
+@Deprecated
 public class AbstractConfig {
 
   private final Logger log = LoggerFactory.getLogger(getClass());

--- a/config/src/main/java/io/confluent/common/config/ConfigDef.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigDef.java
@@ -66,6 +66,7 @@ import io.confluent.common.config.types.Password;
  * This class can be used stand-alone or in combination with {@link AbstractConfig} which provides
  * some additional functionality for accessing configs.
  */
+@Deprecated
 public class ConfigDef {
 
   protected static final Object NO_DEFAULT_VALUE = new Object();

--- a/config/src/main/java/io/confluent/common/config/ConfigException.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigException.java
@@ -37,6 +37,7 @@ package io.confluent.common.config;
 /**
  * Thrown if the user supplies an invalid configuration
  */
+@Deprecated
 public class ConfigException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;

--- a/config/src/main/java/io/confluent/common/config/ConfigUtils.java
+++ b/config/src/main/java/io/confluent/common/config/ConfigUtils.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 
+@Deprecated
 public class ConfigUtils {
   private final static Logger log = LoggerFactory.getLogger(ConfigUtils.class);
 

--- a/config/src/main/java/io/confluent/common/config/types/Password.java
+++ b/config/src/main/java/io/confluent/common/config/types/Password.java
@@ -33,6 +33,7 @@ package io.confluent.common.config.types;
 /**
  * A wrapper class for passwords to hide them while logging a config
  */
+@Deprecated
 public class Password {
 
     public static final String HIDDEN = "[hidden]";


### PR DESCRIPTION
starting the process of getting cp -> ak configs

once we rip it out of downstream deps we can remove this code