### PR TITLE
Skip system, provided, and test scopes in dependency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,9 @@
                         <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
                         <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
                         <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+                        <skipSystemScope>true</skipSystemScope>
+                        <skipProvidedScope>true</skipProvidedScope>
+                        <skipTestScope>true</skipTestScope>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Not skipping these can result in errors in CI due to resolution issues (in particular for the system scope):

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:3.3.4:check (default) on project kafka-connect-hdfs: One or more exceptions occurred during dependency-check analysis: One or more exceptions occurred during analysis:
[ERROR] 	Unable to resolve system scoped dependency: jdk.tools:jdk.tools:jar:1.8:system
```

Scanning these scopes isn't worthwhile anyway because system and provided scopes aren't under control of the project being built (in fact a different version may be provided by the user) and we don't actually ship the test scope so vulnerabilities in the test scope aren't generally relevant.