### PR TITLE
Updated powermock.version for unit test patch usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <!-- Using beta for Java 9 support -->
-        <powermock.version>2.0.0-beta.5</powermock.version>
+        <!-- Update to 2.0.0 for unit test patch usage -->
+        <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.25</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.13</zookeeper.version>


### PR DESCRIPTION
Need to update the powermock.version for unit test patch usage here: https://github.com/confluentinc/blueway/pull/1820/files#r268935692 (the unit test in this PR needs to mock private field as license manager in 5.1.x, which requires latest version of powermock.version: 2.0.0)

Completed the tests by just running `$mvn surefire:test` in the `build.sh` in muckrake and they all passed.