### PR TITLE
Report metric changes to metrics reporters

### DIFF
--- a/metrics/src/main/java/io/confluent/common/metrics/Metrics.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Metrics.java
@@ -210,6 +210,12 @@ public class Metrics {
     }
   }
 
+  void publishMetric(KafkaMetric metric) {
+    for (MetricsReporter reporter : reporters) {
+      reporter.metricChange(metric);
+    }
+  }
+
   /**
    * Get all the metrics currently maintained indexed by metricName
    */

--- a/metrics/src/main/java/io/confluent/common/metrics/Sensor.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Sensor.java
@@ -121,6 +121,7 @@ public final class Sensor {
       }
       checkQuotas(timeMs);
     }
+    publishMetrics();
     for (int i = 0; i < parents.length; i++) {
       parents[i].record(value, timeMs);
     }
@@ -142,6 +143,13 @@ public final class Sensor {
           }
         }
       }
+    }
+  }
+
+  private void publishMetrics() {
+    for (int i = 0; i < this.metrics.size(); i++) {
+      KafkaMetric metric = this.metrics.get(i);
+      registry.publishMetric(metric);
     }
   }
 


### PR DESCRIPTION
This PR fixes a metrics reporting problem with the schema registry (https://github.com/confluentinc/schema-registry/issues/600) and the kafka rest proxy (https://github.com/confluentinc/kafka-rest/issues/516), so that metrics will be reported to custom metrics reporters while the services are running. 