### PR TITLE
Upgrade to dockerfile-maven-plugin with bugfixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <docker.upstream-tag>${docker.tag}</docker.upstream-tag>  <!-- Tag for base images -->
         <docker.test-registry>${docker.upstream-registry}</docker.test-registry>  <!-- Registry for integration test dependencies -->
         <docker.test-tag>${docker.upstream-tag}</docker.test-tag>  <!-- Tag for integration test dependencies -->
-        <dockerfile-maven-plugin.version>1.4.7</dockerfile-maven-plugin.version>
+        <dockerfile-maven-plugin.version>1.4.9</dockerfile-maven-plugin.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This version includes the following fixes from their changelog:

> 1.4.9 (released October 25 2018)
> - Upgrade docker-client dep from 8.14.2 to 8.14.3 to fix spotify/docker-client#1100
> 
> 1.4.8 (released October 23 2018)
> - Upgrade docker-client dep from 8.14.0 to 8.14.2
> - Upgrade com.sparkjava:spark-core to fix CVE-2018-9159
> - Improve documentation on referencing build artifacts
> 

Some of these fixes allow legal docker configs to build correctly,
which the current version throws errors on.