### PR TITLE
Ability to define alternative configurations

### DIFF
--- a/config/src/main/java/io/confluent/common/config/AbstractConfig.java
+++ b/config/src/main/java/io/confluent/common/config/AbstractConfig.java
@@ -80,6 +80,10 @@ public class AbstractConfig {
     logAll();
   }
 
+  protected boolean contains(String key) {
+    return values.containsKey(key);
+  }
+
   protected Object get(String key) {
     if (!values.containsKey(key)) {
       throw new ConfigException(String.format("Unknown configuration '%s'", key));


### PR DESCRIPTION
Add the ability to define exclusive alternatives in configurations (such as "A or B must be specified").
* alternatives are associated by virtue of an "alternative group name", which is purely used for grouping, not visible in the config definition.
* at most one of the alternatives can have a default value. If present, this becomes the default value of the default config for the group. Otherwise, it's required that exactly one config in the group be specified.