### PR TITLE
Add the buildnumber plugin and use it to add the commit sha to jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
+        <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
         <mockito.version>2.23.0</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
@@ -540,7 +541,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>${buildnumber-plugin.version}</version>
                     <executions>
                         <execution>
                             <phase>validate</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Commit-ID>${buildNumber}</Commit-ID>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -529,6 +536,23 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven-dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <doCheck>false</doCheck>
+                        <doUpdate>false</doUpdate>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -603,6 +627,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
                     <configuration>
                         <archive>
                             <manifestEntries>
-                                <Commit-ID>${buildNumber}</Commit-ID>
+                                <Commit-ID>${gitCommitID}</Commit-ID>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -552,6 +552,7 @@
                     <configuration>
                         <doCheck>false</doCheck>
                         <doUpdate>false</doUpdate>
+                        <buildNumberPropertyName>gitCommitID</buildNumberPropertyName>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This patch adds the buildnumber plugin to the common parent pom, and
uses it to add the commit sha to jars. The buildnumber plugin populates
the attribute ${buildNumber} with the git sha, which is then picked up
by the maven archiver and added to the jar manifest.

Build number plugin wiki:
https://www.mojohaus.org/buildnumber-maven-plugin/

Usage:
https://www.mojohaus.org/buildnumber-maven-plugin/usage.html