### PR TITLE
update slf4j version from 1.7.25 to 1.7.26 to fix ST-1837

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.14</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>


### PR DESCRIPTION
Some more details are in ST-1837 , but this is to unblock some failures in operator tests and for operator customers as a result of inconsistency between the version here (1.7.25) and the version used with kafka (1.7.26). We will be fixing in 5.3 at this stage due to the operator requirements and the confidence since this has been running with kafka for some time.

Signed-off-by: sdanduConf <sdandu@confluent.io>