### PR TITLE
ST-2035: Adding the scala version as a property to docker builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -951,6 +951,7 @@
                                         <CONFLUENT_PLATFORM_LABEL>${CONFLUENT_PLATFORM_LABEL}</CONFLUENT_PLATFORM_LABEL>
                                         <CONFLUENT_DEB_VERSION>${CONFLUENT_DEB_VERSION}</CONFLUENT_DEB_VERSION>
                                         <ALLOW_UNSIGNED>${ALLOW_UNSIGNED}</ALLOW_UNSIGNED>
+                                        <SCALA_VERSION>${kafka.scala.version}</SCALA_VERSION>
                                     </buildArgs>
                                     <skip>${docker.skip-build}</skip>
                                     <tag>${docker.tag}</tag>


### PR DESCRIPTION
this property will be used by some of the new docker image builds so i am putting it in the common pom docker step so it doesn't have to be defined in several pom files with in the docker repos.