### PR TITLE
Bump Zookeeper to 3.5.6 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.5.5</zookeeper.version>
+        <zookeeper.version>3.5.6</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Fixes an issue with CP 5.4 not able to start ZK due to https://issues.apache.org/jira/browse/ZOOKEEPER-3056