### PR TITLE
update spotbugs and jacoco for improved jdk support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <ce.kafka.version>5.5.0-ce-SNAPSHOT</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-        <spotbugs.version>3.1.8</spotbugs.version>
-        <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
+        <spotbugs.version>3.1.12</spotbugs.version>
+        <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <!--
          jackson artifacts have both an overall version, and potentially individual versions for artifacts that
@@ -67,7 +67,7 @@
 
         <gson.version>2.8.5</gson.version>
         <guava.version>24.0-jre</guava.version>
-        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <licenses.version>${confluent.version}</licenses.version>


### PR DESCRIPTION
- jacoco now supports jdk13
- spotbugs has improved jdk11 support (includes https://github.com/spotbugs/spotbugs/pull/785)