### PR TITLE
exclude exception classes from ClassDataAbstractionCoupling count

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -241,7 +241,11 @@
         <module name="ParameterNumber">
             <property name="max" value="10"/>
         </module>
-        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassDataAbstractionCoupling">
+            <property name="excludeClassesRegexps"
+                      value="${checkstyle.classdataabstractioncoupling.excludeclassesregexps}"
+                      default="^.*Exception$"/>
+        </module>
         <module name="BooleanExpressionComplexity"/>
         <module name="CyclomaticComplexity"/>
         <module name="JavaNCSS" />


### PR DESCRIPTION
Currently, custom exception classes count towards a classes CDAC count.  This encourages people to use more generic/general exception classes, rather than ones that are more targeted / expressive.

This PR excluded exception classes by default from the CDAC count check, and also makes the set of excluded classes configurable per-project.