### PR TITLE
Update to jackson 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,15 +49,7 @@
         <confluent.version>3.3.4-SNAPSHOT</confluent.version>
         <easymock.version>3.4</easymock.version>
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-        <!--
-         jackson artifacts have both an overall version, and potentially individual versions for artifacts that
-         rev hotfix versions independent of the overall version
-         -->
         <jackson.version>2.9.10</jackson.version>
-        <!-- The following property should default to jackson.version unless there's an independent hotfix version.
-        If so, then once the next version of jackson is released, it should get reset to the default -->
-        <!-- <jackson-databind.version>${jackson.version}</jackson-databind.version> -->
-        <jackson-databind.version>2.9.10.1</jackson-databind.version>
         <jackson.bom.version>2.9.10.20191020</jackson.bom.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,12 @@
          jackson artifacts have both an overall version, and potentially individual versions for artifacts that
          rev hotfix versions independent of the overall version
          -->
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <!-- The following property should default to jackson.version unless there's an independent hotfix version.
         If so, then once the next version of jackson is released, it should get reset to the default -->
         <!-- <jackson-databind.version>${jackson.version}</jackson-databind.version> -->
-        <jackson-databind.version>2.9.9.3</jackson-databind.version>
+        <jackson-databind.version>2.9.10.1</jackson-databind.version>
+        <jackson.bom.version>2.9.10.20191020</jackson.bom.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>
@@ -131,11 +132,13 @@
                 </exclusions>
             </dependency>
 
-            <!-- Jackson artifacts with individual versioning as necessary -->
+            <!-- Jackson artifacts with individual versioning -->
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+              <groupId>com.fasterxml.jackson</groupId>
+              <artifactId>jackson-bom</artifactId>
+              <version>${jackson.bom.version}</version>
+              <scope>import</scope>
+              <type>pom</type>
             </dependency>
 
             <!-- Kafka Deps -->


### PR DESCRIPTION
  - Also switch to using jacksom bom instead of individual artifacts

For 3.3.x:
Verified that 2.9.9.x jackson jars do not exist in packages built from this change. There are still some older jackson jars in the pkg that get pulled in from `kafka` and `kafka-connect-s3` but those don't use jackson from the common pom.

For 5.3.x:
Verified that 2.9.9.x jackson jars do not exist in packages built from this change except for when pulled in by `kafka`.

I haven't tested 5.4.x or master since they appear unstable at the moment, but I don't expect them to be any different.

Note: with this switch to using the jackson bom, we should no longer need to specify the jackson/jackson-databind versions in the common pom anymore. For now, I've left them in for backward compatibility in case any child poms use these properties in their dependencyManagement sections. However, we should really go through and remove any references to jackson in all dependencyManagement sections so that we can inherit directly from the bom.