### PR TITLE
CC-7031: Bump Jackson version to match AK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
         <spotbugs.version>3.1.8</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20191020</jackson.bom.version>
+        <jackson.version>2.10.0</jackson.version>
+        <jackson.bom.version>${jackson.version}</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>24.0-jre</guava.version>


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-7031)

https://github.com/apache/kafka/pull/7411 bumped the Jackson dependency version in AK to 2.10.0; these changes bring CP up to speed with that change.

This change has _not_ been approved as a blocker yet, and should not be merged until/unless it is.