### PR TITLE
Add SuppressWarningsFilter to checkstyle config

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -40,6 +40,8 @@
         <property name="header" value="/\*\nCopyright .* Confluent Inc."/>
     </module>
 
+    <module name="SuppressWarningsFilter" />
+
     <module name="TreeWalker">
         <!-- Generic 'turn all checkstyle off' comment filter -->
         <module name="SuppressionCommentFilter">
@@ -53,6 +55,8 @@
             <property name="onCommentFormat" value="CHECKSTYLE_RULES.ON:\s+([\w\|]+)"/>
             <property name="checkFormat" value="$1"/>
         </module>
+
+        <module name="SuppressWarningsHolder" />
 
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">


### PR DESCRIPTION
This allows the `@SuppressWarnings` annotation to be used to suppress checkstyle violations.

This is more structured than the `// CHECKSTYLE:OFF` comments in that the annotation naturally scopes the suppression to an element in the AST (class, method, statement) without needing a corresponding `// CHECKSTYLE:ON`.

https://checkstyle.sourceforge.io/config_filters.html#SuppressWarningsFilter