### PR TITLE
ST-2560: Adding support for building debian and rhel docker images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,9 @@
         <docker.upstream-tag>${docker.tag}</docker.upstream-tag>  <!-- Tag for base images -->
         <docker.test-registry>${docker.upstream-registry}</docker.test-registry>  <!-- Registry for integration test dependencies -->
         <docker.test-tag>${docker.upstream-tag}</docker.test-tag>  <!-- Tag for integration test dependencies -->
-        <dockerfile-maven-plugin.version>1.4.9</dockerfile-maven-plugin.version>
+        <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <!-- The name of the docker file to run. -->
+        <docker.file>Dockerfile</docker.file>
     </properties>
 
     <scm>
@@ -951,6 +953,7 @@
                                     <tag>${docker.tag}</tag>
                                     <repository>${docker.registry}confluentinc/${project.artifactId}</repository>
                                     <pullNewerImage>false</pullNewerImage>
+                                    <dockerfile>${docker.file}</dockerfile>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Adding a config property to the maven docker plugin so that we can override the name of the Dockerfile to use when building images. This is required so that we can build rhel and debian images. I had to upgrade the docker maven plugin in order to get this feature.