### PR TITLE
MINOR: Bump Guava version to pass dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <jackson.bom.version>2.9.10.20191020</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
-        <guava.version>24.0-jre</guava.version>
+        <guava.version>28.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>
         <kafka.version>2.2.2-SNAPSHOT</kafka.version>


### PR DESCRIPTION
The current Guava version in the POM fails the dependency check stage. This new version does not.

The change here should not have any adverse consequences for repose that utilize this property since any that do should already be failing to build.

We should hold off on merging this until we're out of the blocker phase for 5.4.