### PR TITLE
update cve to json feed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,10 +340,8 @@
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
                         <format>xml</format>
-                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml.gz</cveUrl12Modified>
-                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
-                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
-                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1%d.json.gz</cveUrlBase>
                         <skipSystemScope>true</skipSystemScope>
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipTestScope>true</skipTestScope>

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
                         </suppressionFiles>
                         <format>xml</format>
                         <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1%d.json.gz</cveUrlBase>
+                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
                         <skipSystemScope>true</skipSystemScope>
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
xml feed is removed form 2020, https://nvd.nist.gov/vuln/data-feeds. We should switch to json feed.