### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,7 @@
                         <skipSystemScope>true</skipSystemScope>
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipTestScope>true</skipTestScope>
+                        <format>xml</format>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Problem: Jenkins plugin can not process report after upgrading plugin to 5.2.4 because the default report type change to html in 5.2.4. 

Solution: Change the report formate to xml.