### PR TITLE
Add flag to allow disabling dependency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>5.2.4</dependency.check.version>
         <dependency.check.suppressions.location>dependency-check/suppressions.xml</dependency.check.suppressions.location>
+        <dependency.check.skip>false</dependency.check.skip>
     </properties>
 
     <scm>
@@ -341,6 +342,10 @@
                         </suppressionFiles>
                         <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
                         <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
+                             line. Downstream projects should all be running this as part of their normal builds and should
+                             not override this flag in their pom file. -->
+                        <skip>${dependency.check.skip}</skip>
                         <skipSystemScope>true</skipSystemScope>
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
In a few special cases we may want to allow a build to pass even with
CVEs, in particular to not block publishing SNAPSHOTs during
development.