### PR TITLE
Disable net assembly & oss index report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,8 @@
                         <skipProvidedScope>true</skipProvidedScope>
                         <skipTestScope>true</skipTestScope>
                         <format>xml</format>
+                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION

I don't think we need net assembly since we are purely java code base? This often give some false positive report in logs, like 
```
[2020-02-02T01:20:02.052Z] [ERROR] ----------------------------------------------------
[2020-02-02T01:20:02.052Z] [ERROR] .NET Assembly Analyzer could not be initialized and at least one 'exe' or 'dll' was scanned. The 'dotnet' executable could not be found on the path; either disable the Assembly Analyzer or configure the path dotnet core.
[2020-02-02T01:20:02.052Z] [ERROR] ----------------------------------------------------
```
The oss index contains some vulnerability NVD may not have, but the oss index database connection is unreliable and often cause the build to fail and make the build flaky. like
```
[ERROR] Failed to request component-reports
```
I have seen such error in packaging, system tests jobs and normal branch builders.
 To make the build and system tests more stable, I think we should disable it.  