### PR TITLE
Update to jackson databind 2.9.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <easymock.version>3.4</easymock.version>
         <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
         <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20191020</jackson.bom.version>
+        <jackson.bom.version>2.9.10.20200103</jackson.bom.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Verified that packaging contains 2.9.10.2.
Ref: https://github.com/FasterXML/jackson-bom/blob/d71def80b548af6fb87bcc965eedecb706917a44/pom.xml