### PR TITLE
Upgrade to junit 4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jackson.bom.version>2.9.10.20200223</jackson.bom.version>
 
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
         <kafka.version>0.11.0.4-SNAPSHOT</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <maven-assembly.version>2.6</maven-assembly.version>


### PR DESCRIPTION
junit 4.13 went on GA on January 1, 2020
Adds support for `assertThrows` and other features
