### PR TITLE
ST-3227: Pull down the latest base image version when building docker  images with the maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,7 +957,7 @@
                                     <skip>${docker.skip-build}</skip>
                                     <tag>${docker.tag}</tag>
                                     <repository>${docker.registry}confluentinc/${project.artifactId}</repository>
-                                    <pullNewerImage>false</pullNewerImage>
+                                    <pullNewerImage>true</pullNewerImage>
                                     <dockerfile>${docker.file}</dockerfile>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Setting this to true is the equivalent of using the --pull option when using the docker build CLI. This will make it so we don't use a locally cached version of any base images and always pull down the latest version. This is required so that when we build cp-base-new we go out and get the latest version of the OS base image we use, such as the ubi8 image.