### PR TITLE
ST-3255: Parameterize the option in docker plugin to always pull latest base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,8 @@
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <!-- The name of the docker file to run. -->
         <docker.file>Dockerfile</docker.file>
+        <!-- Pull the latest base image or use a local image. -->
+        <docker.pull-image>false</docker.pull-image>
     </properties>
 
     <scm>
@@ -957,7 +959,7 @@
                                     <skip>${docker.skip-build}</skip>
                                     <tag>${docker.tag}</tag>
                                     <repository>${docker.registry}confluentinc/${project.artifactId}</repository>
-                                    <pullNewerImage>true</pullNewerImage>
+                                    <pullNewerImage>${docker.pull-image}</pullNewerImage>
                                     <dockerfile>${docker.file}</dockerfile>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Turns out we need to set this to true when building our base images, but for our images we build from other cp images created in the same job will fail with this option enabled. I am setting the default to false because that is what it used to be, and it was working correctly for all of our images except for our base image. In a separate commit I will change our base images to set this to true.