### PR TITLE
Disable dependency-check for < 5.0.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@ common {
   // place to trigger the rest of the pipeline. Note that we need to maintain the references to the jobs carefully since they
   // change across version branches.
   upstreamProjects = 'kafka-trunk'
+  nodeLabel = 'docker-oraclejdk7'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,4 @@ common {
   // place to trigger the rest of the pipeline. Note that we need to maintain the references to the jobs carefully since they
   // change across version branches.
   upstreamProjects = 'kafka-trunk'
-  nodeLabel = 'docker-oraclejdk7'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>3.3.4</dependency.check.version>
         <dependency.check.suppressions.location>dependency-check/suppressions.xml</dependency.check.suppressions.location>
-        <dependency.check.skip>true</dependency.check.skip>
+        <dependency.check.skip>false</dependency.check.skip>
     </properties>
 
     <scm>
@@ -340,10 +340,10 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-modified.json.gz</cveUrl12Modified>
-                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrl20Modified>
-                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-%d.json.gz</cveUrl12Base>
-                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrl20Base>
+                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml.gz</cveUrl12Modified>
+                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
+                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
+                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
                         <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>3.3.4</dependency.check.version>
         <dependency.check.suppressions.location>dependency-check/suppressions.xml</dependency.check.suppressions.location>
-        <dependency.check.skip>false</dependency.check.skip>
+        <dependency.check.skip>true</dependency.check.skip>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -340,11 +340,8 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <format>xml</format>
-                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml.gz</cveUrl12Modified>
-                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
-                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
-                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+                        <cveUrl12Modified>https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrl12Modified>
+                        <cveUrl12Base>https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrl12Base>
                         <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->

--- a/pom.xml
+++ b/pom.xml
@@ -340,9 +340,8 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-%d.json.gz</cveUrlBase>
-                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
+                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->
                         <skip>${dependency.check.skip}</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -340,10 +340,10 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml.gz</cveUrl12Modified>
-                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
-                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
-                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml</cveUrl12Modified>
+                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml</cveUrl20Modified>
+                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml</cveUrl12Base>
+                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml</cveUrl20Base>
                         <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->

--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,12 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
+                        <format>xml</format>
+                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-modified.xml.gz</cveUrl12Modified>
+                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-modified.xml.gz</cveUrl20Modified>
+                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-%d.xml.gz</cveUrl12Base>
+                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-2.0-%d.xml.gz</cveUrl20Base>
+                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->
                         <skip>${dependency.check.skip}</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,10 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrl12Modified>https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrl12Modified>
-                        <cveUrl12Base>https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrl12Base>
+                        <cveUrl12Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-modified.json.gz</cveUrl12Modified>
+                        <cveUrl20Modified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrl20Modified>
+                        <cveUrl12Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-%d.json.gz</cveUrl12Base>
+                        <cveUrl20Base>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrl20Base>
                         <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->

--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,8 @@
                         <suppressionFiles>
                             <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
                         </suppressionFiles>
-                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-modified.json.gz</cveUrlModified>
+                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.0-%d.json.gz</cveUrlBase>
                         <!-- Don't use this except in special circumstances as a way to disable this check on the command
                              line. Downstream projects should all be running this as part of their normal builds and should
                              not override this flag in their pom file. -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <zookeeper.version>3.4.10</zookeeper.version>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
-        <dependency.check.version>5.2.4</dependency.check.version>
+        <dependency.check.version>3.3.4</dependency.check.version>
         <dependency.check.suppressions.location>dependency-check/suppressions.xml</dependency.check.suppressions.location>
         <dependency.check.skip>false</dependency.check.skip>
     </properties>


### PR DESCRIPTION
The problem:

3.0.x -> 4.1.x (inclusive) use Java7 to build (at least they should have been). Dependency-Check Maven Plugin`>=4.0.0` no longer supports Java7, so in order for maven to even be able to function, we have to use an older version (or removing it entirely is also an option). However theres anther problem: This version of dependency-check uses XML RSS Fees from NIST, and NIST has deprecated that feed in leu of JSON feeds: https://nvd.nist.gov/General/News/XML-Vulnerability-Feed-Retirement - Which this version doesn't support. At one point we were hosting these feeds in an S3 bucket, but someone deleted them, so they're effectively gone.

The solution:

Hence why I'm disabling the check altogether. Why not disable it and keep the version? The plugin *can't even load* to read that it should skip the check. I acknowledge this isn't an ideal place to be in since we're no longer scanning for CVEs, but we have a secondary check in the docker images using twistlock, so we're not 100% blind. 

I would only pint-merge this change up to 4.1.x, and `-s ours` the rest of the way.

