### PR TITLE
ST-3339: Make dependency-check execution a JDK8 activated profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -592,6 +592,8 @@
             </reporting>
         </profile>
         <profile>
+            <!-- org.owasp:dependency-check-maven >= 4.0.0 will not work with JDK7 so it must be activated in a JDK>=1.8 profile.
+                 Developers can always pass -Ddependency.check.skip=true on the CLI to speed things up during development -->
             <id>dependency-check</id>
             <activation>
                 <jdk>[1.8,)</jdk>

--- a/pom.xml
+++ b/pom.xml
@@ -326,42 +326,6 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>${dependency.check.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.confluent</groupId>
-                            <artifactId>build-tools</artifactId>
-                            <version>${confluent.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <suppressionFiles>
-                            <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
-                        </suppressionFiles>
-                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
-                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
-                             line. Downstream projects should all be running this as part of their normal builds and should
-                             not override this flag in their pom file. -->
-                        <skip>${dependency.check.skip}</skip>
-                        <skipSystemScope>true</skipSystemScope>
-                        <skipProvidedScope>true</skipProvidedScope>
-                        <skipTestScope>true</skipTestScope>
-                        <format>xml</format>
-                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${maven-assembly.version}</version>
@@ -588,10 +552,6 @@
                         </dependency>
                       </dependencies>
                     </plugin>
-                    <plugin>
-                      <groupId>org.owasp</groupId>
-                      <artifactId>dependency-check-maven</artifactId>
-                    </plugin>
                 </plugins>
             </build>
             <reporting>
@@ -630,6 +590,52 @@
                     </plugin>
                 </plugins>
             </reporting>
+        </profile>
+        <profile>
+            <id>dependency-check</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${dependency.check.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.confluent</groupId>
+                            <artifactId>build-tools</artifactId>
+                            <version>${confluent.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <suppressionFiles>
+                            <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
+                        </suppressionFiles>
+                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
+                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
+                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
+                             line. Downstream projects should all be running this as part of their normal builds and should
+                             not override this flag in their pom file. -->
+                        <skip>${dependency.check.skip}</skip>
+                        <skipSystemScope>true</skipSystemScope>
+                        <skipProvidedScope>true</skipProvidedScope>
+                        <skipTestScope>true</skipTestScope>
+                        <format>xml</format>
+                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+               </plugins>
+            </build>
         </profile>
         <profile>
             <id>java-9+</id>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>5.2.4</dependency.check.version>
         <dependency.check.suppressions.location>dependency-check/suppressions.xml</dependency.check.suppressions.location>
-        <dependency.check.skip>false</dependency.check.skip>
+        <dependency.check.skip>true</dependency.check.skip>
     </properties>
 
     <scm>
@@ -505,6 +505,9 @@
                     <name>env.BUILD_NUMBER</name>
                 </property>
             </activation>
+            <properties>
+                <dependency.check.skip>false</dependency.check.skip>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
- dependency-check>=4.0.0 will not run with JDK7. So we conditionalize
the check in a profile thats only activated if JDK>=1.8


## Testing

Original issue:

```
aegelhofer@Andrew-Egelhofer's- common % export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/
aegelhofer@Andrew-Egelhofer's- common % export JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Dhttps.cipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA256"
aegelhofer@Andrew-Egelhofer's- common % mvn -version
Picked up JAVA_TOOL_OPTIONS: -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Dhttps.cipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA256
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /usr/local/Cellar/maven/3.6.3/libexec
Java version: 1.7.0_80, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.4", arch: "x86_64", family: "mac"
aegelhofer@Andrew-Egelhofer's- common % mvn -Pjenkins clean verify
Picked up JAVA_TOOL_OPTIONS: -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Dhttps.cipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA256
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for common 4.0.4-SNAPSHOT:
[INFO]
[INFO] Build Tools ........................................ SUCCESS [  0.631 s]
[INFO] common ............................................. FAILURE [  1.959 s]
[INFO] utils .............................................. SKIPPED
[INFO] metrics ............................................ SKIPPED
[INFO] config ............................................. SKIPPED
[INFO] package ............................................ SKIPPED
[INFO] Common ............................................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.875 s
[INFO] Finished at: 2020-03-30T17:10:37-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:5.2.4:check (default) on project common-parent: Execution default of goal org.owasp:dependency-check-maven:5.2.4:check failed: Unable to load the mojo 'check' in the plugin 'org.owasp:dependency-check-maven:5.2.4' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/owasp/dependencycheck/maven/CheckMojo : Unsupported major.minor version 52.0
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.owasp:dependency-check-maven:5.2.4
```

Now with the changes:

```
aegelhofer@Andrew-Egelhofer's- common % mvn -Pjenkins clean verify
Picked up JAVA_TOOL_OPTIONS: -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Dhttps.cipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA256
[INFO] Scanning for projects...
...
[INFO] Building jar: /Users/aegelhofer/workspace/common/parent/target/common-4.0.4-SNAPSHOT-tests.jar
[INFO]
[INFO] --- maven-failsafe-plugin:2.20.1:integration-test (integration-test) @ common ---
[INFO] No tests to run.
[INFO]
[INFO] --- maven-failsafe-plugin:2.20.1:verify (verify) @ common ---
[INFO]
[INFO] --- jacoco-maven-plugin:0.7.9:report (report) @ common ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for common 4.0.4-SNAPSHOT:
[INFO]
[INFO] Build Tools ........................................ SUCCESS [  0.637 s]
[INFO] common ............................................. SUCCESS [  1.638 s]
[INFO] utils .............................................. SUCCESS [  1.373 s]
[INFO] metrics ............................................ SUCCESS [  3.564 s]
[INFO] config ............................................. SUCCESS [  2.798 s]
[INFO] package ............................................ SUCCESS [  1.021 s]
[INFO] Common ............................................. SUCCESS [  0.256 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.598 s
[INFO] Finished at: 2020-03-30T17:11:02-07:00
[INFO] ------------------------------------------------------------------------
```

Now switch back to JDK8:

```
aegelhofer@Andrew-Egelhofer's- common % unset JAVA_TOOL_OPTIONS JAVA_HOME
aegelhofer@Andrew-Egelhofer's- common % mvn -version
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /usr/local/Cellar/maven/3.6.3/libexec
Java version: 1.8.0_232, vendor: AdoptOpenJDK, runtime: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.4", arch: "x86_64", family: "mac"
aegelhofer@Andrew-Egelhofer's- common % mvn -Pjenkins clean verify
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
...
[INFO] --- dependency-check-maven:5.2.4:check (default) @ common-parent ---
[INFO] Checking for updates
[INFO] Skipping NVD check since last check was within 4 hours.
[INFO] Skipping RetireJS update since last update was within 24 hours.
[INFO] Check for updates complete (6 ms)
[INFO]

Dependency-Check is an open source tool performing a best effort analysis of 3rd party dependencies; false positives and false negatives may exist in the analysis performed by the tool. Use of the tool and the reporting provided constitutes acceptance for use in an AS IS condition, and there are NO warranties, implied or otherwise, with regard to the analysis or its use. Any use of the tool and the reporting provided is at the user’s risk. In no event shall the copyright holder or OWASP be held liable for any damages whatsoever arising out of or in connection with the use of this tool, the analysis performed, or the resulting report.


[INFO] Analysis Started
...
[WARNING]

One or more dependencies were identified with known vulnerabilities in utils:

log4j-1.2.16.jar (pkg:maven/log4j/log4j@1.2.16, cpe:2.3:a:apache:log4j:1.2.16:*:*:*:*:*:*:*) : CVE-2019-17571
netty-3.10.5.Final.jar (pkg:maven/io.netty/netty@3.10.5.Final, cpe:2.3:a:netty:netty:3.10.5:*:*:*:*:*:*:*) : CVE-2019-16869, CVE-2019-20444, CVE-2019-20445


See the dependency-check report for more details.

...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for common 4.0.4-SNAPSHOT:
[INFO]
[INFO] Build Tools ........................................ SUCCESS [  0.500 s]
[INFO] common ............................................. SUCCESS [  4.021 s]
[INFO] utils .............................................. SUCCESS [  2.811 s]
[INFO] metrics ............................................ SUCCESS [  4.177 s]
[INFO] config ............................................. SUCCESS [  3.244 s]
[INFO] package ............................................ SUCCESS [  1.885 s]
[INFO] Common ............................................. SUCCESS [  1.175 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.058 s
[INFO] Finished at: 2020-03-30T17:11:48-07:00
[INFO] ------------------------------------------------------------------------
```

A caveat with this approach: Since I removed the plugin's run from the `jenkins` profile, this will *always* be ran, but I don't know of a way in maven to "if the `jenkins` profile is activated & JDK>=1.8 do this..." - even so, someone can always pass `-Dcheck.dependency-skip=true` if they want to disable it for their testing purposes.

## More to come

After this PR is merged, I will go to `jenkins-common`, and in the `common` module, I'll add a new stage/stp called "Dependency Check" that runs the build with JDK8 thereby allowing the dependency-check to continue (just using a newer JVM).