### PR TITLE
update various maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <kafka.version>6.0.0-ccs-SNAPSHOT</kafka.version>
         <ce.kafka.version>6.0.0-ce-SNAPSHOT</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
-        <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-        <spotbugs.version>3.1.12</spotbugs.version>
-        <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <spotbugs.version>4.0.2</spotbugs.version>
+        <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.10.2</jackson.version>
         <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
@@ -65,18 +65,18 @@
         <kafka.scala.version>2.12</kafka.scala.version>
         <licenses.version>${confluent.version}</licenses.version>
         <maven-assembly.version>3.0.0</maven-assembly.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-        <maven-deploy.version>2.8.2</maven-deploy.version>
-        <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+        <maven-deploy.version>3.0.0-M1</maven-deploy.version>
+        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
+        <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
         <mockito.version>2.23.0</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
-        <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+        <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -87,10 +87,10 @@
         <zookeeper.version>3.5.7</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
-        <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+        <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+        <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>5.2.4</dependency.check.version>
@@ -409,7 +409,9 @@
                     <configuration>
                         <configLocation>${checkstyle.config.location}</configLocation>
                         <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
-                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectories>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        </sourceDirectories>
                         <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
@@ -741,7 +743,9 @@
                         <configuration>
                             <configLocation>${checkstyle.config.location}</configLocation>
                             <suppressionsLocation>${checkstyle.suppressions.location}</suppressionsLocation>
-                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                            <sourceDirectories>
+                                <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                            </sourceDirectories>
                             <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>false</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,9 @@
         <kafka.version>6.0.0-ccs-SNAPSHOT</kafka.version>
         <ce.kafka.version>6.0.0-ce-SNAPSHOT</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
-        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
+             running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
+        <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
         <spotbugs.version>4.0.2</spotbugs.version>
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>


### PR DESCRIPTION
- many plugins now require maven 3.x
- many bugfixes and improvement for recent JDK versions
- major version upgrades:
  * checkstyle plugin 3.1.1
  * surefire plugin 3.0.0-M4
  * spotbugs plugin 4.0.0 (spotbugs 4.0.2)
  * deploy plugin 3.0.0-M1
  * intall plugin 3.0.0-M1
- remove deprecated checkstyle configs

did spot-checks on a few downstream repos and didn't see issues, in no way exhaustive though.