### PR TITLE
Update ZooKeeper to 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.5.7</zookeeper.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>


### PR DESCRIPTION
It fixes 30 issues, including third party CVE fixes, several leader-election related fixes and a
compatibility issue with applications built against earlier 3.5 client libraries (by restoring a few
non public APIs).

See ZooKeeper 3.5.8 Release Notes for details: https://zookeeper.apache.org/doc/r3.5.8/releasenotes.html