### PR TITLE
ST-3461: Implement nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 common {
     upstreamProjects = ['confluentinc/license-file-generator']
-    slackChannel = '#kafka-warn'
+    slackChannel = ''
+    testbreakReporting = false
 }

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0-0</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0-0</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python
+
+import os
+import logging
+import re
+import subprocess
+import sys
+
+from xml.etree import ElementTree as ET
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+log = logging.getLogger(__name__)
+
+NAME_SPACE = "{http://maven.apache.org/POM/4.0.0}"
+
+
+class CIUpdate:
+
+    def __init__(self, new_version, repo_path):
+        """Initialize class variables"""
+        # List of all the files that were modified by this script so the parent
+        # script that runs this update can commit them.
+        self.updated_files = []
+        # The new version
+        self.new_version = new_version
+        # The path the root of the repo so we can use full absolute paths
+        self.repo_path = repo_path
+
+    def run_update(self):
+        """Update all the files with the new version"""
+        log.info("Running additional version updates for common")
+        self.resolve_ccs_kafka_version()
+        self.resolve_ce_kafka_version()
+        log.info("Finished all common additional version updates.")
+
+    def resolve_ccs_kafka_version(self):
+        """Resolve the version range property for ccs kafka."""
+        log.info("Resolving the version range for ccs kafka.")
+        property_name="kafka.version"
+        version_range = self.get_version_range(property_name)
+        version = self.resolve_version_range(version_range, "CCS")
+        self.set_property(property_name=property_name, property_value=version)
+        log.info("Finished resolving the version range for ccs kafka.")
+
+    def resolve_ce_kafka_version(self):
+        """Resolve the version range property for ce kafka."""
+        log.info("Resolving the version range for ce kafka.")
+        property_name="ce.kafka.version"
+        version_range = self.get_version_range(property_name)
+        version = self.resolve_version_range(version_range, "CE")
+        self.set_property(property_name=property_name, property_value=version)
+        log.info("Finished resolving the version range for ce kafka.")
+
+    def get_version_range(self, property_name):
+        """Parse pom file and extract property value."""
+        log.info("Getting version range for: {}.".format(property_name))
+        pom = ET.ElementTree()
+        pom.parse(os.path.join(self.repo_path, "pom.xml"))
+        properties = pom.getroot().find("{}properties".format(NAME_SPACE))
+        version_range = properties.find("{}{}".format(NAME_SPACE, property_name)).text
+
+        if version_range is not None:
+            version_range = version_range.strip()
+            log.info("Version range for {} is: {}".format(property_name, version_range))
+            return version_range
+        else:
+            log.error("Failed to get value for property: {}".format(property_name))
+            sys.exit(1)
+
+    def resolve_version_range(self, version_range, print_method):
+        """Run the custom maven resolver plugin to find the latest artifact version in the range."""
+        # We just use one of the kafka artifacts to resolve the range. No particular reason for using this artifact.
+        group_id = "org.apache.kafka"
+        artifact_id = "kafka-clients"
+        # TODO: Remove the snapshot version here when done testing.
+        cmd = "mvn --batch-mode -Pjenkins io.confluent:resolver-maven-plugin:1.0.0-SNAPSHOT:resolve-kafka-range "
+        cmd += "-DgroupId={} ".format(group_id)
+        cmd += "-DartifactId={} ".format(artifact_id)
+        cmd += "-DversionRange=\"{}\" ".format(version_range)
+        # TODO: Final version of plugin we shouldn't need to specify what version to print
+        cmd += "-Dprint{} -q".format(print_method)
+        log.info("Resolving the version range for: {}".format(version_range))
+        result, stdout = self.run_cmd(cmd, return_stdout=True)
+
+        if result:
+            # When run from Jenkins there will be additional output included so we just get the last line of output.
+            version = stdout.strip().splitlines()[-1]
+            log.info("Resolved the version range to version: {}".format(version))
+            return version
+        else:
+            log.error("Failed to resolve the version range.")
+            sys.exit(1)
+
+    def run_cmd(self, cmd, return_stdout=False):
+        """Execute a shell command. Return true if successful, false otherwise."""
+        log.info(cmd)
+        proc = subprocess.Popen(cmd,
+                                cwd=self.repo_path,
+                                shell=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                universal_newlines=True)
+        stdout = proc.communicate()
+
+        if stdout:
+            log.info(stdout)
+
+        if proc.returncode != 0:
+            if return_stdout:
+                return False, stdout
+            else:
+                return False
+        elif return_stdout:
+            return True, stdout
+        else:
+            return True
+
+    def set_property(self, property_name, property_value):
+        """Update the project version property in the pom file.
+        Each property follows the format: io.confluent.<repo>.version
+        """
+        cmd = "mvn --batch-mode versions:set-property "
+        cmd += "-DgenerateBackupPoms=false "
+        cmd += "-Dproperty={} ".format(property_name)
+        cmd += "-DnewVersion={}".format(property_value)
+        log.info("Setting the property {} to {}".format(property_name, property_value))
+
+        if self.run_cmd(cmd):
+            log.info("Finished setting the property.")
+        else:
+            log.error("Failed to set the property.")
+            sys.exit(1)

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <artifactId>common-config</artifactId>
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <properties>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-logging</artifactId>
-            <version>${confluent.version}</version>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <properties>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-logging</artifactId>
-            <version>${confluent.version}</version>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <artifactId>common-package</artifactId>
@@ -35,19 +35,22 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>build-tools</artifactId>
-            <version>${confluent.version}</version>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-config</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-metrics</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
     </dependencies>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <artifactId>common</artifactId>
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
+            <version>${io.confluent.common.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0-0</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -47,9 +47,8 @@
         <argLine></argLine>
         <avro.version>1.9.2</avro.version>
         <required.maven.version>3.2</required.maven.version>
-        <confluent.version>6.0.0-SNAPSHOT</confluent.version>
-        <kafka.version>6.0.0-ccs-SNAPSHOT</kafka.version>
-        <ce.kafka.version>6.0.0-ce-SNAPSHOT</ce.kafka.version>
+        <kafka.version>[6.0.0-0-ccs, 6.0.1-0-ccs)</kafka.version>
+        <ce.kafka.version>[6.0.0-0-ce, 6.0.1-0-ce)</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -59,9 +58,9 @@
         <java.version>8</java.version>
         <jackson.version>2.10.2</jackson.version>
         <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
-
         <gson.version>2.8.5</gson.version>
         <guava.version>28.1-jre</guava.version>
+        <io.confluent.license-file-generator.version>[6.0.0-0, 6.0.1-0)</io.confluent.license-file-generator.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <junit.version>4.13</junit.version>
         <kafka.scala.version>2.13</kafka.scala.version>
@@ -70,7 +69,7 @@
         <maven-assembly.version>3.0.0</maven-assembly.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-        <maven-deploy.version>3.0.0-M1</maven-deploy.version>
+        <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -121,6 +120,10 @@
         <!-- Pull the latest base image or use a local image. -->
         <docker.pull-image>false</docker.pull-image>
         <dependency.check.skip>true</dependency.check.skip>
+        <io.confluent.common.version>6.0.0-0</io.confluent.common.version>
+        <!-- Controls whether we run the maven resolver plugin which is used to resolve the version ranges for kafka and ce-kafka.
+             We want to run this for local builds, but disable this in the jenkins profile so it doesn't run during CI builds. -->
+        <skip.maven.resolver.plugin>false</skip.maven.resolver.plugin>
     </properties>
 
     <scm>
@@ -296,21 +299,31 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
+            <!-- We need to resolve the ce.kafka.version range during this build,
+            and in order to do that we must declare a dependency in this pom
+            on a kafka artifact using that version. That is the only reason we
+            have this dependency declared here.-->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>${ce.kafka.version}</version>
+            </dependency>
+
             <!--this is our own artifacts, but lets others inherit-->
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>common-config</artifactId>
-                <version>${confluent.version}</version>
+                <version>${io.confluent.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>common-metrics</artifactId>
-                <version>${confluent.version}</version>
+                <version>${io.confluent.common.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>common-utils</artifactId>
-                <version>${confluent.version}</version>
+                <version>${io.confluent.common.version}</version>
             </dependency>
 
             <!--test deps-->
@@ -402,7 +415,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>assembly-plugin-boilerplate</artifactId>
-            <version>${confluent.version}</version>
+            <version>${io.confluent.common.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -441,7 +454,7 @@
                         <dependency>
                             <groupId>io.confluent</groupId>
                             <artifactId>build-tools</artifactId>
-                            <version>${confluent.version}</version>
+                            <version>${io.confluent.common.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
@@ -696,6 +709,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.confluent</groupId>
+                <artifactId>resolver-maven-plugin</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <configuration>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                    <!--TODO: this will be different in downstream builds, double check that is behavior we want.-->
+                    <!--TODO: using license version range is temporary for testing-->
+                    <versionRange>${io.confluent.license-file-generator.version}</versionRange>
+                    <skip>${skip.maven.resolver.plugin}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                    <phase>${resolver.maven.plugin.phase}</phase>
+                        <goals>
+                            <goal>resolve-kafka-range</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -781,6 +815,11 @@
             </activation>
             <properties>
                 <dependency.check.skip>false</dependency.check.skip>
+                <!-- During CI builds we do not want to execute this plugin to
+                resolve the kafka version ranges because the CI tooling will 
+                resolve the range and update the property in the pom file. 
+                This plugin should only be used for building locally. -->
+                <skip.maven.resolver.plugin>true</skip.maven.resolver.plugin>
             </properties>
             <build>
                 <pluginManagement>
@@ -886,7 +925,7 @@
                         <dependency>
                             <groupId>io.confluent</groupId>
                             <artifactId>build-tools</artifactId>
-                            <version>${confluent.version}</version>
+                            <version>${io.confluent.common.version}</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -976,7 +1015,7 @@
                                 <configuration>
                                     <skipAssembly>${docker.skip-build}</skipAssembly>
                                     <descriptors>
-                                        <descriptor>target/dependency/assembly-plugin-boilerplate-${confluent.version}/common-docker-package.xml</descriptor>
+                                        <descriptor>target/dependency/assembly-plugin-boilerplate-${io.confluent.common.version}/common-docker-package.xml</descriptor>
                                     </descriptors>
                                     <archive>
                                         <manifest>
@@ -1046,7 +1085,7 @@
                             <dependency>
                                 <groupId>io.confluent</groupId>
                                 <artifactId>licenses</artifactId>
-                                <version>${licenses.version}</version>
+                                <version>${io.confluent.license-file-generator.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0-0</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
For the initial roll out of nano versioning which will only affect how we build kafka and ce-kafka all of these changes will not be made. The only changes to common will be to add the version resolver plugin we created so that we can resolve version ranges for kafka and ce-kafka, and the version properties for kafka and ce kafka will be changed to version ranges. This repo will still be built as a snapshot artifact and will not be built with a build number until we roll out nano versioning to the rest of the repos.

There are several changes in this PR that are just for testing and will be reverted in the final PR.
- Test break reporting will be re-enabled.
- The slack channel will be reverted back.
- 