### PR TITLE
downgrade maven-deploy-plugin to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <maven-assembly.version>3.0.0</maven-assembly.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
-        <maven-deploy.version>3.0.0-M1</maven-deploy.version>
+        <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -94,7 +94,7 @@
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>


### PR DESCRIPTION
also downgrades intall plugin to 2.5.2 since 3.0.0-M1 of install
plugin requires 3.0.0-M1 of deploy plugin according to releaes notes
https://blogs.apache.org/maven/entry/apache-maven-install-plugin-version

This is required becauses some components in our build environment are
still relying on deploy plugin 2.7.x, which prevents us from switching
to the new 3.0.x syntax for alt*DeploymentRepository which requires
removing the 'layout' component of the repo.
see https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html