### PR TITLE
ST-3458: Nano versioning for kafka and ce-kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 *.iml
 .idea/
 .ipr
+installed_pom.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,6 @@
 common {
     upstreamProjects = ['confluentinc/license-file-generator']
     slackChannel = '#kafka-warn'
+    // We do not want to enable nano versioning for the first phase of the roll out
+    nanoVersion = false
 }

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+
+import os
+import logging
+import re
+import shlex
+import subprocess
+import sys
+
+from xml.etree import ElementTree as ET
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+log = logging.getLogger(__name__)
+
+NAME_SPACE = "{http://maven.apache.org/POM/4.0.0}"
+
+
+class CI:
+
+    def __init__(self, new_version, repo_path):
+        """Initialize class variables"""
+        # List of all the files that were modified by this script so the parent
+        # script that runs this update can commit them.
+        self.updated_files = []
+        # The new version
+        self.new_version = new_version
+        # The path the root of the repo so we can use full absolute paths
+        self.repo_path = repo_path
+
+    def run_update(self):
+        """Update all the files with the new version"""
+        log.info("Running additional version updates for common")
+        self.resolve_ccs_kafka_version()
+        self.resolve_ce_kafka_version()
+        self.updated_files.append("pom.xml")
+        log.info("Finished all common additional version updates.")
+
+    def resolve_ccs_kafka_version(self):
+        """Resolve the version range property for ccs kafka."""
+        log.info("Resolving the version range for ccs kafka.")
+        property_name="kafka.version"
+        version_range = self.get_version_range(property_name)
+        version = self.resolve_version_range(version_range, "CCS")
+        self.set_property(property_name=property_name, property_value=version)
+        log.info("Finished resolving the version range for ccs kafka.")
+
+    def resolve_ce_kafka_version(self):
+        """Resolve the version range property for ce kafka."""
+        log.info("Resolving the version range for ce kafka.")
+        property_name="ce.kafka.version"
+        version_range = self.get_version_range(property_name)
+        version = self.resolve_version_range(version_range, "CE")
+        self.set_property(property_name=property_name, property_value=version)
+        log.info("Finished resolving the version range for ce kafka.")
+
+    def get_version_range(self, property_name):
+        """Parse pom file and extract property value."""
+        log.info("Getting version range for: {}.".format(property_name))
+        pom = ET.ElementTree()
+        pom.parse(os.path.join(self.repo_path, "pom.xml"))
+        properties = pom.getroot().find("{}properties".format(NAME_SPACE))
+        version_range = properties.find("{}{}".format(NAME_SPACE, property_name)).text
+
+        if version_range is not None:
+            version_range = version_range.strip()
+            log.info("Version range for {} is: {}".format(property_name, version_range))
+            return version_range
+        else:
+            log.error("Failed to get value for property: {}".format(property_name))
+            sys.exit(1)
+
+    def resolve_version_range(self, version_range, print_method):
+        """Run the custom maven resolver plugin to find the latest artifact version in the range."""
+        # We just use one of the kafka artifacts to resolve the range. No particular reason for using this artifact.
+        group_id = "org.apache.kafka"
+        artifact_id = "kafka-clients"
+        cmd = "mvn --batch-mode -Pjenkins io.confluent:resolver-maven-plugin:0.2.0:resolve-kafka-range "
+        cmd += "-DgroupId={} ".format(group_id)
+        cmd += "-DartifactId={} ".format(artifact_id)
+        cmd += "-DversionRange=\"{}\" ".format(version_range)
+        # If we don't set this property to false it will skip running this when
+        # run from Jenkins because the profile sets the skip value to true.
+        cmd += "-Dskip.maven.resolver.plugin=false "
+        cmd += "-Dprint{} -q".format(print_method)
+        log.info("Resolving the version range for: {}".format(version_range))
+        result, stdout = self.run_cmd(cmd, return_stdout=True)
+  
+        if result:
+            # When run from Jenkins there will be additional output included so we just get the last line of output.
+            version = stdout.strip().splitlines()[-1]
+            # Make sure we got a valid version back and the script didn't silently fail.
+            match_result = re.match("[0-9]*\\.[0-9]*\\.[0-9]*-[0-9]*-{}".format(print_method.lower()), version)
+
+            if match_result:
+                log.info("Resolved the version range to version: {}".format(version))
+                return version
+
+        log.error("Failed to resolve the version range.")
+        sys.exit(1)
+
+    def run_cmd(self, cmd, return_stdout=False):
+        """Execute a shell command. Return true if successful, false otherwise."""
+        log.info(cmd)
+        cmd = shlex.split(cmd)
+        proc = subprocess.Popen(cmd,
+                                cwd=self.repo_path,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                                universal_newlines=True)
+        stdout, _ = proc.communicate()
+
+        if stdout:
+            log.info(stdout)
+
+        if proc.returncode != 0:
+            if return_stdout:
+                return False, stdout
+            else:
+                return False
+        elif return_stdout:
+            return True, stdout
+        else:
+            return True
+
+    def set_property(self, property_name, property_value):
+        """Update the project version property in the pom file.
+        Each property follows the format: io.confluent.<repo>.version
+        """
+        cmd = "mvn --batch-mode versions:set-property "
+        cmd += "-DgenerateBackupPoms=false "
+        cmd += "-Dproperty={} ".format(property_name)
+        cmd += "-DnewVersion={}".format(property_value)
+        log.info("Setting the property {} to {}".format(property_name, property_value))
+
+        if self.run_cmd(cmd):
+            log.info("Finished setting the property.")
+        else:
+            log.error("Failed to set the property.")
+            sys.exit(1)

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -41,10 +41,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <avro.version>1.9.2</avro.version>
         <required.maven.version>3.2</required.maven.version>
         <confluent.version>6.1.0-SNAPSHOT</confluent.version>
-        <kafka.version>6.1.0-ccs-SNAPSHOT</kafka.version>
-        <ce.kafka.version>6.1.0-ce-SNAPSHOT</ce.kafka.version>
+        <kafka.version>[6.1.0-0-ccs, 6.1.1-0-ccs)</kafka.version>
+        <ce.kafka.version>[6.1.0-0-ce, 6.1.1-0-ce)</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -121,6 +121,33 @@
         <!-- Pull the latest base image or use a local image. -->
         <docker.pull-image>false</docker.pull-image>
         <dependency.check.skip>true</dependency.check.skip>
+        <!-- This is a version of the pom file that we install and deploy because
+            the kafka and ce-kafka version ranges are resolved.
+        -->
+        <installed.pom.file>installed_pom.xml</installed.pom.file>
+        <coderplus.plugin.version>1.0</coderplus.plugin.version>
+        <!-- This version range is only used in the custom resolver plugin for 
+            resolving the version of ccs and ce kafka. This property should 
+            never be used any where else.
+        -->
+        <confluent.version.range>[6.1.0-0, 6.1.1-0)</confluent.version.range>
+        <!-- Controls whether we run the maven resolver plugin which is used to resolve
+            the version ranges for kafka and ce-kafka. We want to run this for local builds,
+            but disable this in the jenkins profile so it doesn't run during CI builds.
+        -->
+        <skip.maven.resolver.plugin>false</skip.maven.resolver.plugin>
+        <!-- The custom install step handles installing a modified pom file with the
+            kafka version ranges resolved. We only do this for local builds so for 
+            CI builds we set the phase to none.
+        -->
+        <custom.install.phase>install</custom.install.phase>
+        <!-- The custom deploy step handles copying the modified pom over the 
+            standard pom so that we deploy a pom with the kafka versions resolved.
+            We only do this for local builds so for 
+            CI builds we set the phase to none.
+        -->
+        <custom.deploy.phase>deploy</custom.deploy.phase>
+        <maven.resolver.plugin.version>0.2.0</maven.resolver.plugin.version>
     </properties>
 
     <scm>
@@ -696,6 +723,80 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- This custom resolver plugin is used to resolve the version ranges
+                for kafka and ce-kafka since they don't use the standard version scheme.
+                This will set the properties kafka.version and ce.kafka.version
+            -->
+            <plugin>
+                <groupId>io.confluent</groupId>
+                <artifactId>resolver-maven-plugin</artifactId>
+                <version>${maven.resolver.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                    <phase>validate</phase>
+                        <goals>
+                            <goal>resolve-kafka-range</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                    <versionRange>${confluent.version.range}</versionRange>
+                    <skip>${skip.maven.resolver.plugin}</skip>
+                </configuration>
+            </plugin>
+            <!-- This custom install plugin is run so that we install the common
+                artifact using a the pom with the kafka and ce-kafka version
+                range properties resolved to a specific version.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>${maven-install-plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>custom-install</id>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <phase>${custom.install.phase}</phase>
+                        <configuration>
+                          <file>${installed.pom.file}</file>
+                          <groupId>io.confluent</groupId>
+                          <artifactId>common-parent</artifactId>
+                          <packaging>pom</packaging>
+                          <version>${project.version}</version>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- This custom deploy plugin is run so that when we deploy the common
+                artifact we use a version of the pom file with the kafka and
+                ce-kafka version range properties resolved to a specific version.
+            -->
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>${coderplus.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <id>copy-file</id>
+                        <phase>${custom.deploy.phase}</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <overWrite>true</overWrite>
+                            <sourceFile>${basedir}/${installed.pom.file}</sourceFile>
+                            <destinationFile>${basedir}/pom.xml</destinationFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -781,6 +882,22 @@
             </activation>
             <properties>
                 <dependency.check.skip>false</dependency.check.skip>
+                <!-- During CI builds we do not want to execute the resolver plugin
+                    or the additional install and deploy steps as they are only
+                    needed when building locally.
+                -->
+                <!-- For the first phase of the nano versioning roll out we
+                    want the CI builds to resolve the kafka versions in the
+                    installed pom because we are not producing nano versioned
+                    artifacts for common, and so the custom update script is not
+                    being run which would normally update the pom files. This
+                    will be enabled in the second phase of the roll out when
+                    we produce nano versioned artifacts for common.
+
+                <skip.maven.resolver.plugin>true</skip.maven.resolver.plugin>
+                <custom.install.phase>none</custom.install.phase>
+                <custom.deploy.phase>none</custom.deploy.phase>
+                -->
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
For the first phase of the nano versioning roll out we are only going to implement nano versioning for kafka and ce-kafka. I am updating the common repo to use version ranges for those two repos and adding the custom maven resolver plugin so that we can resolve those custom version ranges.