### PR TITLE
SEC-1034: log4j migration to confluent repackaged version

### DIFF
--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -35,9 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
@@ -294,6 +295,17 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>confluent-log4j</artifactId>
+                <version>${confluent-log4j.version}</version>
             </dependency>
 
             <!--this is our own artifacts, but lets others inherit-->

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,7 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
                 <exclusions>
+                    <!-- Use a repackaged version of log4j with security patches instead-->
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
@@ -303,6 +304,7 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <!-- Security patches to the end-of-life log4j 1.2.17 -->
                 <groupId>io.confluent</groupId>
                 <artifactId>confluent-log4j</artifactId>
                 <version>${confluent-log4j.version}</version>


### PR DESCRIPTION
- Confluent repackaged version fixes CVE-2019-17571
- all downstream dependencies that use `slf4j-log4j12` must explicitly include the following
```
   <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>confluent-log4j</artifactId>
       <version>${confluent-log4j.version}</version>
   </dependency>
```

There is a cyclic dependency in PR build success. This PR will not show a green build unless the downstream dependencies are all building fine. Those downstream dependencies will not build green unless they can get `${confluent-log4j.version}` definition from the updated `common/pom.xml`.
