### PR TITLE
METRICS-1918: bump gson from 2.8.5 -> 2.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jackson.version>2.10.2</jackson.version>
         <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
 
-        <gson.version>2.8.5</gson.version>
+        <gson.version>2.8.6</gson.version>
         <guava.version>28.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <junit.version>4.13</junit.version>


### PR DESCRIPTION
### what
Upgrade gson from 2.8.5 -> 2.8.6.

### why
Align with other repos using Gson.