### PR TITLE
ST-3988: Update jackson version to 2.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.10.4</jackson.version>
-        <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
+        <jackson.bom.version>2.10.4</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>28.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <spotbugs.version>3.1.8</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.10.4</jackson.version>
         <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
         <spotbugs.version>3.1.8</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.4</jackson.version>
-        <jackson.bom.version>2.10.4</jackson.bom.version>
+        <jackson.version>2.10.5</jackson.version>
+        <jackson.bom.version>2.10.5</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>28.1-jre</guava.version>


### PR DESCRIPTION
For jackson version 2.10.2, `jackson-dataformat-yaml` brings in snakeyaml v1.24, which is supposedly affected by CVE-2017-18640