### PR TITLE
SEC-1305: update jackson-bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20200223</jackson.bom.version>
+        <jackson.bom.version>2.9.10.20200621</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>28.1-jre</guava.version>


### PR DESCRIPTION
It bumps jackson databind version to 2.9.10.5 which fixes about 16 critical CVEs as compared to the current 2.9.10.2
Details here: https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.9.10.20200621

Once approved, this same update can be applied all the way back to 3.3.x using `git cherry-pick`.
5.4.x onward are on jackson version 2.10.5. So a pull request against oldest and pint merge all the way to `master` probably wouldn't have worked anyways.