### PR TITLE
SEC-1305: update zk version to match that of 5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
-        <zookeeper.version>3.4.14</zookeeper.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>


### PR DESCRIPTION
zookeeper v3.4.14 brings in `io.netty:netty:3.10.6` which has known CVEs.
5.4.x is already on zookeeper v3.5.8 which relies on an upgraded netty version