### PR TITLE
SEC-1334: update confluent-log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>


### PR DESCRIPTION
This pull request updates `confluent-log4j` from `1.2.17-cp1` to `1.2.17-cp2`. The former had a few accidental commits that made the repackaged version slightly different than the upstream `log4j`. `1.2.17-cp2` fixes the issue and applies a CVE fix (and no additional code changes) to the upstream `log4j:1.2.17`.