### PR TITLE
ST-3461: Nano versioning: do not run custom resolver plugin in ci builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,5 @@
 common {
     upstreamProjects = ['confluentinc/license-file-generator']
     slackChannel = '#kafka-warn'
-    // We do not want to enable nano versioning for the first phase of the roll out
-    nanoVersion = false
+    nanoVersion = true
 }

--- a/pom.xml
+++ b/pom.xml
@@ -900,18 +900,9 @@
                     or the additional install and deploy steps as they are only
                     needed when building locally.
                 -->
-                <!-- For the first phase of the nano versioning roll out we
-                    want the CI builds to resolve the kafka versions in the
-                    installed pom because we are not producing nano versioned
-                    artifacts for common, and so the custom update script is not
-                    being run which would normally update the pom files. This
-                    will be enabled in the second phase of the roll out when
-                    we produce nano versioned artifacts for common.
-
                 <skip.maven.resolver.plugin>true</skip.maven.resolver.plugin>
                 <custom.install.phase>none</custom.install.phase>
                 <custom.deploy.phase>none</custom.deploy.phase>
-                -->
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
This brings back the original process that we will use in the second phase of the roll out where the CI builds do not use the custom resolver, install, and deploy steps. We will now need to run the ci.py script to update the pom file with the resolved kafka versions. The way it was did not work and the deployed pom file was not correct so we need to use this process that is a little more hacky in the first phase of the roll out. I will need to update the ci-tools script so that during the first phase of the roll out it runs the ci.py script but doesn't do the other updates for the common repo. I will have another PR explaining that.