### PR TITLE
ST-3461: Add option to provide additional maven settings to the maven command in the ci script

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -75,7 +75,16 @@ class CI:
         # We just use one of the kafka artifacts to resolve the range. No particular reason for using this artifact.
         group_id = "org.apache.kafka"
         artifact_id = "kafka-clients"
-        cmd = "mvn --batch-mode -Pjenkins io.confluent:resolver-maven-plugin:0.2.0:resolve-kafka-range "
+        cmd = "mvn --batch-mode -Pjenkins "
+        # When running this from packaging we need to provide the maven command additional args,
+        # such as point at another repo. In packaging if we don't override the repo then it
+        # doesn't find the resolver plugin.
+        mvn_args = os.getenv("MAVEN_ARGS")
+
+        if mvn_args:
+            cmd += "{} ".format(mvn_args)
+
+        cmd += "io.confluent:resolver-maven-plugin:0.2.0:resolve-kafka-range "
         cmd += "-DgroupId={} ".format(group_id)
         cmd += "-DartifactId={} ".format(artifact_id)
         cmd += "-DversionRange=\"{}\" ".format(version_range)


### PR DESCRIPTION
When we run the ci.py script from packaging build_artifacts it will fail because it can't find the maven resolver plugin. That is because during those build_artifact builds we pass in a custom settings file to point at a different repo, and in that repo we do have the resolver plugin. So we need a way to pass in these args to this script so that when it calls maven it also uses that other repo. The script will now check for a maven environment variable with additional args and add them to the command it uses to run the resolver plugin.

I will have another PR to update the packaging script to export this environment variable with the additional settings.

I tested this locally by running the script and exporting an environment variable to make sure it added it correctly to the maven command.

This PR shows it being used in the packaging build.
https://github.com/confluentinc/packaging/pull/814/files