### PR TITLE
ST-3461: Nano version: skip custom plugins during packaging build for archive build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ ifeq ($(PULL_ARTIFACTS),yes)
 	BUILD_METHOD = newbuild
 endif
 
+MVN_SETTINGS=-Dskip.maven.resolver.plugin=true -Dcustom.install.phase=none -Dcustom.deploy.phase=none
+
 all: install
 
 archive: install
@@ -75,9 +77,9 @@ endif
 
 build:
 ifeq ($(SKIP_TESTS),yes)
-	mvn -DskipTests=true install
+	mvn -B $(MVN_SETTINGS) -DskipTests=true install
 else
-	mvn install
+	mvn -B $(MVN_SETTINGS) install
 endif
 	./create_archive.sh
 


### PR DESCRIPTION
Do not run the custom plugins such as the resolver plugin during this build because we already resolved the kafka version ranges. I did not enable the jenkins profile which would skip these plugins because that would also change other behavior, so I am passing in these properties that cause the three plugins to get skipped. This is backwards compatible with older releases since nothing will be affected since these properties didn't exist prior to 6.1.0.

I also changed the maven command to run in batch mode so we don't get all the progress logging when downloading artifacts.

I tested this by running a packaging PR build using this branch.