### PR TITLE
ST-3461: Nano version: skip custom plugins during packaging build for rpm.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ export PREFIX
 export SYSCONFDIR
 export SKIP_TESTS
 
+MVN_SETTINGS=-Dskip.maven.resolver.plugin=true -Dcustom.install.phase=none -Dcustom.deploy.phase=none
+
 all: install
 
 
@@ -77,9 +79,9 @@ endif
 
 build: apply-patches
 ifeq ($(SKIP_TESTS),yes)
-	mvn -DskipTests=true install
+	mvn -B -DskipTests=true $(MVN_SETTINGS) install
 else
-	mvn install
+	mvn -B $(MVN_SETTINGS) install
 endif
 
 install: build


### PR DESCRIPTION
Do not run the custom plugins such as the resolver plugin during this build because we already resolved the kafka version ranges. I did not enable the jenkins profile which would skip these plugins because that would also change other behavior, so I am passing in these properties that cause the three plugins to get skipped. This is backwards compatible with older releases since nothing will be affected since these properties didn't exist prior to 6.1.0.

I also changed the maven command to run in batch mode so we don't get all the progress logging when downloading artifacts.

I tested this by running a packaging PR build using this branch.