### PR TITLE
ST-3461: Specify the new pom file name when running the resolver plugin

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO, format='%(message)s')
 log = logging.getLogger(__name__)
 
 NAME_SPACE = "{http://maven.apache.org/POM/4.0.0}"
-RESOLVER_PLUGIN_VERSION = "0.3.0"
+RESOLVER_PLUGIN_VERSION = "0.4.0"
 
 
 class CI:

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
             CI builds we set the phase to none.
         -->
         <custom.deploy.phase>deploy</custom.deploy.phase>
-        <maven.resolver.plugin.version>0.3.0</maven.resolver.plugin.version>
+        <maven.resolver.plugin.version>0.4.0</maven.resolver.plugin.version>
     </properties>
 
     <scm>
@@ -758,6 +758,7 @@
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
                     <versionRange>${confluent.version.range}</versionRange>
+                    <newPomFile>${installed.pom.file}</newPomFile>
                     <skip>${skip.maven.resolver.plugin}</skip>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The latest version of the custom maven resolver plugin requires you to specify the name of the new pom file you want to create otherwise it does not create one by default. The common pom build should be creating the installed pom file like it was before the change to the plugin so this will do that. Tested locally to make sure the file was created.