### PR TITLE
SEC-1307: Backporting log4j swap with confluent-repackaged version

### DIFF
--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -35,9 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
@@ -277,6 +278,19 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+                <exclusions>
+                    <!-- Use a repackaged version of log4j with security patches instead-->
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <!-- Security patches to the end-of-life log4j 1.2.17 -->
+                <groupId>io.confluent</groupId>
+                <artifactId>confluent-log4j</artifactId>
+                <version>${confluent-log4j.version}</version>
             </dependency>
 
             <!--this is our own artifacts, but lets others inherit-->

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>


### PR DESCRIPTION
Cherry-picking two commits from master: one commit that changes upstream log4j with our confluent repackaged version (cp1), and another commit that changes cp1 => cp2.