### PR TITLE
fix: Update checkstyle.xml

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -42,6 +42,11 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="LineLength">
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- Generic 'turn all checkstyle off' comment filter -->
         <module name="SuppressionCommentFilter">
@@ -68,10 +73,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="100"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="UnusedImports"/>


### PR DESCRIPTION
According to:

https://github.com/checkstyle/checkstyle/issues/2116

Since the Checkstyle version 8.26 released on Nov 14, 2019;
the `LineLength` element has to be direct descendent of `Checker` 