### PR TITLE
Update maven resolver plugin. Do not fail if ce-kafka version is not resolved.

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -14,7 +14,7 @@ logging.basicConfig(level=logging.INFO, format='%(message)s')
 log = logging.getLogger(__name__)
 
 NAME_SPACE = "{http://maven.apache.org/POM/4.0.0}"
-RESOLVER_PLUGIN_VERSION = "0.4.0"
+RESOLVER_PLUGIN_VERSION = "0.5.0"
 
 
 class CI:

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,8 @@
             CI builds we set the phase to none.
         -->
         <custom.deploy.phase>deploy</custom.deploy.phase>
-        <maven.resolver.plugin.version>0.4.0</maven.resolver.plugin.version>
+        <maven.resolver.plugin.version>0.5.0</maven.resolver.plugin.version>
+        <fail.if.ce-kafka.version.not.found>false</fail.if.ce-kafka.version.not.found>
     </properties>
 
     <scm>
@@ -760,6 +761,8 @@
                     <versionRange>${confluent.version.range}</versionRange>
                     <newPomFile>${installed.pom.file}</newPomFile>
                     <skip>${skip.maven.resolver.plugin}</skip>
+                    <failIfCCSNotfound>true</failIfCCSNotfound>
+                    <failIfCENotfound>${fail.if.ce-kafka.version.not.found}</failIfCENotfound>
                 </configuration>
             </plugin>
             <!-- This custom install plugin is run so that we install the common
@@ -904,6 +907,10 @@
                 <skip.maven.resolver.plugin>true</skip.maven.resolver.plugin>
                 <custom.install.phase>none</custom.install.phase>
                 <custom.deploy.phase>none</custom.deploy.phase>
+                <!-- During CI builds we need to fail if we are unable to resolve
+                    the latest version of ce-kafka artifacts.
+                -->
+                <fail.if.ce-kafka.version.not.found>true</fail.if.ce-kafka.version.not.found>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
Problem:
Open source contributors could not build the common repo because it would fail to resolve the version range for ce-kafka because they don't have access to those artifacts.

Solution:
The new version of the maven resolver plugin has an option for not failing when it can't resolve one of the kafka version ranges. I set it to always fail if it can't resolve the ccs kafka version range because people should always have access to those artifacts. For the ce-kafka version range it will not fail when running locally if it can not resolve that version range, but will fail during CI builds if it can not find ce-kafka artifacts.

When testing this locally I made sure it works when not connected to our internal artifactory instances which mimics the behavior of some one from open source community running this. Also, @xli1996 uploaded the plugin to maven central and I verified that it was able to download it from there when not connected to any of our internal artifactory instances.