### PR TITLE
SEC-1474---Upgraded bcpkix-jdk15on to 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
-        <bouncycastle.version>1.60</bouncycastle.version>
+        <bouncycastle.version>1.66</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>


### PR DESCRIPTION
The version 1.60 of bcpkix-jdk15on caused a list of vulnerabilities. We need upgrade it to 1.66. 