### PR TITLE
MINOR: Update jackson databind to 2.10.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.10.5</jackson.version>
-        <jackson.bom.version>2.10.5</jackson.bom.version>
+        <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>28.1-jre</guava.version>


### PR DESCRIPTION
This pull request updates jackson-databind to 2.10.5.1, which fixes CVE-2020-25649. Jackson-bom transition from 2.10.5 => 2.10.5.20201202 only updates jackson-databind, and doesn't affect other jackson jars. See [here](https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom/2.10.5.20201202).

Ideally, this should be applied to all the branches from 5.4.x to master. I don't expect any merge issues, since all branches are currently on the same version.