### PR TITLE
Update jackson.version to 2.10.5.1 to resolve CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <spotbugs.version>4.0.2</spotbugs.version>
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.5</jackson.version>
+        <jackson.version>2.10.5.1</jackson.version>
         <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
 
         <gson.version>2.8.6</gson.version>


### PR DESCRIPTION
The `jackson-databind:jar:2.10.5` has a CVE-2020-25649 - https://nvd.nist.gov/vuln/detail/CVE-2020-25649.
It's fixed in `2.10.5.1`.