### PR TITLE
MINOR: Bump version of maven-project-info-reports-plugin to 3.1.1

### DIFF
--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -34,7 +34,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -41,7 +41,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-        <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
+        <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
You know those ERRORS that dont' seem to cause build failures about "Unknown packaging: bundle"? These ones:

```
[WARNING] Unable to create Maven project for com.fasterxml.jackson.module:jackson-module-scala_2.10:jar:2.10.5 from repository.
[2021-02-26T17:33:11.320Z] org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[2021-02-26T17:33:11.320Z] [ERROR] Unknown packaging: bundle @ line 6, column 16
[2021-02-26T17:33:11.320Z] 
[2021-02-26T17:33:11.320Z]     at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:207)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:342)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.RepositoryUtils.getMavenProjectFromRepository (RepositoryUtils.java:125)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.getDependencyRow (DependencyManagementRenderer.java:253)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderDependenciesForScope (DependencyManagementRenderer.java:202)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderDependenciesForAllScopes (DependencyManagementRenderer.java:151)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderSectionProjectDependencies (DependencyManagementRenderer.java:144)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderBody (DependencyManagementRenderer.java:130)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.reporting.AbstractMavenReportRenderer.render (AbstractMavenReportRenderer.java:80)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.report.projectinfo.DependencyManagementReport.executeReport (DependencyManagementReport.java:107)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.reporting.AbstractMavenReport.generate (AbstractMavenReport.java:251)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument (ReportDocumentRenderer.java:267)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render (DefaultSiteRenderer.java:349)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.plugins.site.render.SiteMojo.renderLocale (SiteMojo.java:198)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.plugins.site.render.SiteMojo.execute (SiteMojo.java:147)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
[2021-02-26T17:33:11.320Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
[2021-02-26T17:33:11.320Z]     at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2021-02-26T17:33:11.320Z]     at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
[2021-02-26T17:33:11.320Z]     at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2021-02-26T17:33:11.320Z]     at java.lang.reflect.Method.invoke (Method.java:498)
[2021-02-26T17:33:11.320Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2021-02-26T17:33:11.320Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2021-02-26T17:33:11.320Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2021-02-26T17:33:11.320Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2021-02-26T17:33:11.321Z] Caused by: org.apache.maven.model.building.ModelBuildingException: 1 problem was encountered while building the effective model for com.fasterxml.jackson.module:jackson-module-scala_2.10:2.10.5
[2021-02-26T17:33:11.321Z] [ERROR] Unknown packaging: bundle @ line 6, column 16
[2021-02-26T17:33:11.321Z] 
[2021-02-26T17:33:11.321Z]     at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException (DefaultModelProblemCollector.java:197)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:498)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:440)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:430)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:173)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:342)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.RepositoryUtils.getMavenProjectFromRepository (RepositoryUtils.java:125)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.getDependencyRow (DependencyManagementRenderer.java:253)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderDependenciesForScope (DependencyManagementRenderer.java:202)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderDependenciesForAllScopes (DependencyManagementRenderer.java:151)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderSectionProjectDependencies (DependencyManagementRenderer.java:144)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.renderBody (DependencyManagementRenderer.java:130)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.reporting.AbstractMavenReportRenderer.render (AbstractMavenReportRenderer.java:80)
[2021-02-26T17:33:11.321Z]     at org.apache.maven.report.projectinfo.DependencyManagementReport.executeReport (DependencyManagementReport.java:107)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.reporting.AbstractMavenReport.generate (AbstractMavenReport.java:251)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument (ReportDocumentRenderer.java:267)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render (DefaultSiteRenderer.java:349)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.plugins.site.render.SiteMojo.renderLocale (SiteMojo.java:198)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.plugins.site.render.SiteMojo.execute (SiteMojo.java:147)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
[2021-02-26T17:33:11.576Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
[2021-02-26T17:33:11.576Z]     at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2021-02-26T17:33:11.576Z]     at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
[2021-02-26T17:33:11.576Z]     at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2021-02-26T17:33:11.576Z]     at java.lang.reflect.Method.invoke (Method.java:498)
[2021-02-26T17:33:11.576Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2021-02-26T17:33:11.577Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2021-02-26T17:33:11.577Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2021-02-26T17:33:11.577Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```

Well there is a (closed) issue in the FasterXML project: https://github.com/FasterXML/jackson-module-scala/issues/393

On the plugin side this "bug" can be found here: https://issues.apache.org/jira/browse/MPIR-374

Which is addressed in version 3.1.1: https://www.lightnetics.com/topic/27586/apache-maven-project-info-reports-plugin-version-3-1-1-released

This is not really a "fix" per-say, as it merely supresses the stack trace behind a WARN log:

```
[WARNING] Unable to create Maven project for com.fasterxml.jackson.module:jackson-module-scala_2.10:jar:2.10.5 from repository.
[WARNING] Unable to create Maven project for com.fasterxml.jackson.module:jackson-module-scala_2.11:jar:2.10.5 from repository.
[WARNING] Unable to create Maven project for com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:2.10.5 from repository.
[WARNING] Unable to create Maven project for com.fasterxml.jackson.module:jackson-module-scala_2.13:jar:2.10.5 from repository.
```

But it at least makes reading/groking logs easier for developer lives.