### PR TITLE
ST-5085:Update resolver plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
             CI builds we set the phase to none.
         -->
         <custom.deploy.phase>deploy</custom.deploy.phase>
-        <maven.resolver.plugin.version>0.5.0</maven.resolver.plugin.version>
+        <maven.resolver.plugin.version>0.6.0</maven.resolver.plugin.version>
         <fail.if.ce-kafka.version.not.found>false</fail.if.ce-kafka.version.not.found>
         <io.confluent.license-file-generator.version>${confluent.version.range}</io.confluent.license-file-generator.version>
     </properties>


### PR DESCRIPTION
# what
https://github.com/confluentinc/common/issues/317
Resolver plugin causes build failures when it has fixed version `versionRange`. I fixed it in resolver 0.6.0. https://github.com/confluentinc/resolver-maven-plugin/pull/7

# how
Update resolver plugin version to 0.6.0

# test
Try to apply the same change on 6.1.0-post branch or 6.1.0 tag