### PR TITLE
KREST-1066 Upgrade Guava to the latest version to patch CVE-2020-8908.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <jackson.bom.version>2.9.10.20200621</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
-        <guava.version>28.1-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <junit.version>4.13</junit.version>
         <kafka.version>2.2.3-SNAPSHOT</kafka.version>


### PR DESCRIPTION
Downstream validation passed here, but more importantly, it also passed on `master` (see #327 and its related CI runs).
It's a bit too much to test the same on every branch between `5.2.x` and `master`. Because of that, I'll go with the assumption that no problems on the two opposite sides (`5.2.x` and `master`) is a good enough indication that there would be no problems on the in-between branches too.