### PR TITLE
ST-5293: Upgrading jackson because of CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <spotbugs.version>4.2.0</spotbugs.version>
         <spotbugs.maven.plugin.version>4.2.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.5</jackson.version>
+        <jackson.version>2.10.5.1</jackson.version>
         <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
         <gson.version>2.8.6</gson.version>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
Upgrading the version of jackson to resolve the cve.