### PR TITLE
ST-5293: Explicit load of netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,11 @@
                     </exclusion>
                     <exclusion>
                         <groupId>io.netty</groupId>
-                        <artifactId>netty-codec</artifactId>
+                        <artifactId>netty-handler</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport-native-epoll</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -347,7 +351,12 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-codec</artifactId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
                 <version>${netty.version}</version>
             </dependency>
 


### PR DESCRIPTION
The way I had excluded the netty dependencies from zookeeper before resulted in getting a mix of versions that caused incompatibility issues between netty libraries when they were used in other modules. This change makes it so that all of the direct dependencies zookeeper has on netty are excluded and then explicitly loaded. 

This doesn't fix all of the downstream issues with rest-utils though, but it does fix some of the test issues. That is because rest-utils is not getting netty through zookeeper but from another dependency which includes other netty libraries so still get a mix. I have another PR for rest-utils to address this. I did run rest-utils and the tests with this change and those other changes and they passed several times.

I ran the dependency tree from common-docker utility belt where zookeeper is used to make sure they are all on the same version.

[INFO] io.confluent:utility-belt:jar:6.2.0-0
[INFO] +- org.apache.zookeeper:zookeeper:test-jar:tests:3.5.9:test
[INFO] |  +- io.netty:netty-handler:jar:4.1.63.Final:test
[INFO] |  |  \- io.netty:netty-resolver:jar:4.1.63.Final:test
[INFO] |  \- io.netty:netty-transport-native-epoll:jar:4.1.63.Final:test
[INFO] |     \- io.netty:netty-transport-native-unix-common:jar:4.1.63.Final:test
[INFO] \- io.netty:netty-codec:jar:4.1.63.Final:test
[INFO]    +- io.netty:netty-common:jar:4.1.63.Final:test
[INFO]    +- io.netty:netty-buffer:jar:4.1.63.Final:test
[INFO]    \- io.netty:netty-transport:jar:4.1.63.Final:test