### PR TITLE
APPSEC-70: Upgrade zookeeper to 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>


### PR DESCRIPTION
To keep consistent with https://github.com/confluentinc/common/blob/5.5.x/pom.xml