### PR TITLE
DGS-1551: upgrade jackson-bom to 2.9.10.20210106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <spotbugs.maven.plugin.version>3.1.8</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20200621</jackson.bom.version>
+        <jackson.bom.version>2.9.10.20210106</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
This will upgrade jackson-databind to `2.9.10.8` which will fix CVEs below 
```
com.fasterxml.jackson.core_jackson-databind 2.9.10.5  -- Upgrade options: 2.10.5.1 (CVEs Fixed), 2.10.5.1 (Recommended), 2.12.3 (Optimal)

       [cvss: 8.10 ] CVE-2020-24750 ['fixed in 2.9.10.6']

       [cvss: 8.10 ] CVE-2021-20190 ['fixed in 2.9.10.7']

       [cvss: 8.10 ] CVE-2020-35728 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36189 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36188 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36179 ['fixed in 2.9.10.8']

       [cvss: 9.80 ] CVE-2018-14718 ['fixed in 2.9.7']

       [cvss: 8.10 ] CVE-2020-36181 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-24616 ['fixed in 2.9.10.6']

       [cvss: 7.50 ] CVE-2020-25649 ['fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4']

       [cvss: 8.10 ] CVE-2020-36180 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36183 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-35490 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36182 ['fixed in 2.9.10.8']

       [cvss: 9.80 ] CVE-2018-7489 ['fixed in 2.9.5, 2.8.11.1, 2.7.9.3']

       [cvss: 8.10 ] CVE-2020-36185 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36184 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-35491 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36187 ['fixed in 2.9.10.8']

       [cvss: 8.10 ] CVE-2020-36186 ['fixed in 2.9.10.8']
```

Jackson release note for 2.9 can be found [here](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9) 

**Testing**
Green build and downstream validation pass.