### PR TITLE
Fix zookeeper, jacksondatabind and jackson-cbor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,9 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20210106</jackson.bom.version>
+        <jackson.version>2.10.5.1</jackson.version>
+        <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
+        <jackson.cbor.version>2.11.4</jackson.cbor.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -83,7 +84,7 @@
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.25</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
@@ -203,6 +204,11 @@
               <version>${jackson.bom.version}</version>
               <scope>import</scope>
               <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>${jackson.cbor.version}</version>
             </dependency>
 
             <!-- Kafka Deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.5.1</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
         <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
         <jackson.cbor.version>2.11.4</jackson.cbor.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.25</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
-        <zookeeper.version>3.5.8</zookeeper.version>
+        <zookeeper.version>3.5.9</zookeeper.version>
         <bouncycastle.version>1.60</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>


### PR DESCRIPTION
This is the process for syncing versions of libraries for June security release. This probably will break downstream build. We will coordinate teams to fix them.