### PR TITLE
Fix jacksondatabind and jackson-cbor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,9 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.9.10</jackson.version>
-        <jackson.bom.version>2.9.10.20210106</jackson.bom.version>
+        <jackson.version>2.10.5</jackson.version>
+        <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
+        <jackson.cbor.version>2.11.4</jackson.cbor.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -204,6 +205,11 @@
               <version>${jackson.bom.version}</version>
               <scope>import</scope>
               <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>${jackson.cbor.version}</version>
             </dependency>
 
             <!-- Kafka Deps -->


### PR DESCRIPTION
This is to sync versions of common libraries from 5.2.x: https://github.com/confluentinc/common/commit/494caf87aa432337823c3ad2b25f554b0fd46112