### PR TITLE
APPSEC-110: Exclude Netty in zookeeper 3.4.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.101tec</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -51,6 +51,10 @@
                     <artifactId>log4j</artifactId>
                     <groupId>log4j</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Netty is only required for tls support and that was only added in ZK 3.5.x