### PR TITLE
ST-5057: security patch release support for rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION=$(shell grep \<version\> pom.xml | head -n 1 | awk -F'>|<' '{ print $$3 
 endif
 
 export PACKAGE_TITLE=confluent-common
-export PACKAGE_NAME=$(PACKAGE_TITLE)-$(VERSION)
+export PACKAGE_NAME=$(PACKAGE_TITLE)-$(VERSION)$(SECURITY_SUFFIX)
 
 # Defaults that are likely to vary by platform. These are cleanly separated so
 # it should be easy to maintain altered values on platform-specific branches

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -10,7 +10,7 @@ if [ -z ${PACKAGE_TITLE} -o -z ${VERSION} -o -z ${DESTDIR} ]; then
     exit 1
 fi
 
-if [[ -n ${SECURITY_PATCH} ]]
+if [[ -n ${SECURITY_PATCH} ]]; then
 VERSION=${VERSION}-${SECURITY_PATCH}
 fi
 

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -10,6 +10,10 @@ if [ -z ${PACKAGE_TITLE} -o -z ${VERSION} -o -z ${DESTDIR} ]; then
     exit 1
 fi
 
+if [[ -n ${SECURITY_PATCH} ]]
+VERSION=${VERSION}-${SECURITY_PATCH}
+fi
+
 BINPATH=${PREFIX}/bin
 LIBPATH=${PREFIX}/share/${PACKAGE_TITLE}
 DOCPATH=${PREFIX}/share/doc/${PACKAGE_TITLE}

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -10,10 +10,6 @@ if [ -z ${PACKAGE_TITLE} -o -z ${VERSION} -o -z ${DESTDIR} ]; then
     exit 1
 fi
 
-if [[ -n ${SECURITY_PATCH} ]]; then
-VERSION=${VERSION}-${SECURITY_PATCH}
-fi
-
 BINPATH=${PREFIX}/bin
 LIBPATH=${PREFIX}/share/${PACKAGE_TITLE}
 DOCPATH=${PREFIX}/share/doc/${PACKAGE_TITLE}
@@ -27,7 +23,7 @@ mkdir -p ${DESTDIR}${BINPATH}
 mkdir -p ${DESTDIR}${LIBPATH}
 mkdir -p ${DESTDIR}${SYSCONFDIR}
 
-PREPACKAGED="package/target/common-package-${VERSION}-package"
+PREPACKAGED="package/target/common-package-${VERSION}${SECURITY_SUFFIX}-package"
 pushd ${PREPACKAGED}
 find . -type f | grep -v README[.]rpm | xargs -I XXX ${INSTALL} -o root -g root XXX ${DESTDIR}${PREFIX}/XXX
 popd


### PR DESCRIPTION
# what
Support new security patch release pattern.

# how
Add new security suffix for packaging name.