### PR TITLE
update easymock for Java 16 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[7.1.0-0-ccs, 7.1.1-0-ccs)</kafka.version>
         <ce.kafka.version>[7.1.0-0-ce, 7.1.1-0-ce)</ce.kafka.version>
-        <easymock.version>4.0.1</easymock.version>
+        <easymock.version>4.3</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>


### PR DESCRIPTION
Release notes: https://github.com/easymock/easymock/releases/tag/easymock-4.3