### PR TITLE
log4j migration to confluent repackaged version

### DIFF
--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -35,9 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
+        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
@@ -155,6 +156,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Security patches to the end-of-life log4j 1.2.17 -->
+                <groupId>io.confluent</groupId>
+                <artifactId>confluent-log4j</artifactId>
+                <version>${confluent-log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
-        <confluent-log4j.version>1.2.17-cp1</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Update to 2.0.0 for unit test patch usage -->

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,13 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+                <exclusions>
+                    <!-- Use a repackaged version of log4j with security patches instead-->
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!--this is our own artifacts, but lets others inherit-->


### PR DESCRIPTION
Apply https://github.com/confluentinc/common/pull/270/files to 5.2 and 5.3