### PR TITLE
SEC-1789 Bump bouncycastle to fix CVE-2020-28052 (#309)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <zkclient.version>0.10</zkclient.version>
         <zookeeper.version>3.4.14</zookeeper.version>
-        <bouncycastle.version>1.60</bouncycastle.version>
+        <bouncycastle.version>1.68</bouncycastle.version>
         <checkstyle.version>8.18</checkstyle.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>


### PR DESCRIPTION
(cherry picked from commit 0ff2e314ed04a89f731c1fe427fdcdde28edaec6)