### PR TITLE
update checkstyle to 8.44 and fix checks

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -42,6 +42,11 @@
 
     <module name="SuppressWarningsFilter" />
 
+    <module name="LineLength">
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <!-- Generic 'turn all checkstyle off' comment filter -->
         <module name="SuppressionCommentFilter">
@@ -68,10 +73,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="100"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="UnusedImports"/>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <bouncycastle.version>1.68</bouncycastle.version>
         <jmx_prometheus_javaagent.version>0.14.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.6.2</jolokia-jvm.version>
-        <checkstyle.version>8.18</checkstyle.version>
+        <checkstyle.version>8.44</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>

--- a/utils/src/main/java/io/confluent/common/Configurable.java
+++ b/utils/src/main/java/io/confluent/common/Configurable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
-/**
+/*
  * Original license:
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more

--- a/utils/src/main/java/io/confluent/common/utils/AbstractPerformanceTest.java
+++ b/utils/src/main/java/io/confluent/common/utils/AbstractPerformanceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.common.utils;
 

--- a/utils/src/main/java/io/confluent/common/utils/IntegrationTest.java
+++ b/utils/src/main/java/io/confluent/common/utils/IntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- **/
+ */
 
 package io.confluent.common.utils;
 

--- a/utils/src/main/java/io/confluent/common/utils/MockTime.java
+++ b/utils/src/main/java/io/confluent/common/utils/MockTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
-/**
+/*
  * Original license:
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE

--- a/utils/src/main/java/io/confluent/common/utils/PerformanceStats.java
+++ b/utils/src/main/java/io/confluent/common/utils/PerformanceStats.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.common.utils;
 


### PR DESCRIPTION
* update checkstyle to support recent Java versions – release notes: https://checkstyle.sourceforge.io/releasenotes.html#Release_8.44
* LineLength must now defined under Checker
* fix license comments incorrectly using javadoc style