### PR TITLE
fix change in checkstyle behavior since 8.20

### DIFF
--- a/build-tools/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle/checkstyle.xml
@@ -93,6 +93,13 @@
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
+        <module name="SuppressionXpathSingleFilter">
+            <!-- allow empty {}, see https://github.com/checkstyle/checkstyle/issues/7541
+                 taken from https://github.com/checkstyle/checkstyle/blob/422be612a4dce54f204094449f3de75d248e2871/src/main/resources/google_checks.xml#L99-L104 -->
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                          or preceding-sibling::*[last()][self::LCURLY]]"/>
+        </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
             <property name="allowEmptyMethods" value="true"/>


### PR DESCRIPTION
workaround for https://github.com/checkstyle/checkstyle/issues/7541
taken from https://github.com/checkstyle/checkstyle/blob/422be612a4dce54f204094449f3de75d248e2871/src/main/resources/google_checks.xml#L99-L104

this is to help backport checkstyle version upgrades and to reduce the impact on additional downstream repositories, thanks @dimitarndimitrov for the suggestion.