### PR TITLE
Upgrade Jackson to 2.12.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
         <spotbugs.version>4.2.0</spotbugs.version>
         <spotbugs.maven.plugin.version>4.2.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.10.5</jackson.version>
-        <jackson.bom.version>2.10.5.20201202</jackson.bom.version>
-        <jackson.cbor.version>2.11.4</jackson.cbor.version>
+        <jackson.version>2.12.3</jackson.version>
+        <jackson.bom.version>2.12.3</jackson.bom.version>
+        <jackson.cbor.version>2.12.3</jackson.cbor.version>
 
         <gson.version>2.8.6</gson.version>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
AK 3.0 has been upgrade to this version https://github.com/apache/kafka/pull/10778 and we want to keep it consistent in corresponding CP branches. 