### PR TITLE
[AUDIT-415] Update confluent-log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp3</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <netty.version>4.1.63.Final</netty.version>


### PR DESCRIPTION
Update version of confluent-log4j to v.1.2.17-cp3. The new version of confluent-log4j adds logredactor v1.0.1 as a dependency. This will allow everything that uses confluent-log4j to also have access to log redactor. 

More details on logredactor:
- https://github.com/confluentinc/logredactor
- https://confluentinc.atlassian.net/wiki/spaces/SECENG/pages/2227276875/1-Pager+Cloud+Log4j+Redactor