### PR TITLE
Upgrade Netty to 4.1.68.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.9</zookeeper.version>
-        <netty.version>4.1.63.Final</netty.version>
+        <netty.version>4.1.68.Final</netty.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <jmx_prometheus_javaagent.version>0.14.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.6.2</jolokia-jvm.version>


### PR DESCRIPTION
This is to upgrade Netty to fix: CVE-2021-37137