### PR TITLE
Update confluent-log4j version to 1.2.17-cp4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp3</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp4</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
Update confluent-log4j version. 

This new version updated logredactor version from 1.0.1 to 1.0.3 - details on logredactor changes can be found here: https://github.com/confluentinc/confluent-log4j/pull/8#pullrequestreview-789944279