### PR TITLE
Add license to assembly-plugin-boilerplate

### DIFF
--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -1,3 +1,19 @@
+<!--~
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--~
   ~ Copyright 2018 Confluent Inc.
   ~


### PR DESCRIPTION
Add license to assembly-plugin-boilerplate

This is cloned from https://github.com/confluentinc/common/pull/388 
cc @cjolivier01 