### PR TITLE
Add license header in pom.xml

### DIFF
--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~
+  ~ Copyright 2021 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0


### PR DESCRIPTION
Add license header in pom.xml in assembly-plugin-boilerplate

Background: As part of [Open source license scanning](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2631631350/Running+FOSSA+for+open+source+license+scanning) initiativate, when scanning connect repos, `assembly-plugin-boilerplate` is flagged as No license found.
Hence adding the header in pom.xml