### PR TITLE
chore: update mockito to last available 3.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
-        <mockito.version>3.11.2</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
Mockito 4.x has been released, updating to the latest 3.x series
so we can start removing deprecated APIs before moving to 4.x