### PR TITLE
Add Support to Split Up Integration Tests for Junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
@@ -695,7 +695,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>@{argLine} -Djava.awt.headless=true</argLine>
-                    <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
+                    <excludedGroups>io.confluent.common.utils.IntegrationTest, IntegrationTest</excludedGroups>
                 </configuration>
                 <executions>
                     <execution>
@@ -711,9 +711,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <argLine>@{argLine} -Djava.awt.headless=true</argLine>
-                    <groups>io.confluent.common.utils.IntegrationTest</groups>
+                    <groups>io.confluent.common.utils.IntegrationTest, IntegrationTest</groups>
                     <!-- by default failsafe only includes class names that start or end in IT,
-                         we use regular test class names with @Category and the group above -->
+                         we use regular test class names with @Category and the group above. For
+                         Junit5 we add an "IntegrationTest" tag -->
                     <includes>
                         <!-- defaults copied from maven-surefire-plugin -->
                         <include>**/Test*.java</include>


### PR DESCRIPTION
Junit5 uses [Tags](https://junit.org/junit5/docs/current/user-guide/#writing-tests-tagging-and-filtering) instead of Category and we can only use string instead of the IntegrationTest class that we import from here when defining integration tests. To get around this, we add a new IntegrationTest group to filter on in the maven-surefire-plugin and maven-failsafe-plugin when splitting out the integration tests