### PR TITLE
Revert confluent-log4j cp5 to cp2 for log4j concerns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp5</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
log4j2 2.15 also has CVE and we should wait for them to be stabilized.
log4j-cp only has log4j 1.x.
This only applies to master branch.