### PR TITLE
Bump confluent-log4j to 1.2.17-cp6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp4</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp6</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
  - Cherrypick of #400
  - Needed to get downstream 7.1.x branches compiling without the vulnerable log4j2 versions. Earlier 7.0.x versions depend on confluent-log4j 1.2.17-cp2, which isn't vulnerable.