### PR TITLE
Revert confluent-log4j to cp2 (7.1.x only)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp6</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <netty.version>4.1.68.Final</netty.version>


### PR DESCRIPTION
We do not plan to ship log redactor in 7.1.x of CP. 
Do not pint this to master as it is required for master branch.