### PR TITLE
[SEC-2896] Update confluent-log4j version to cp8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp6</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>


### PR DESCRIPTION
This new version of confluent-log4j removes several classes involved with log4j 1.x CVEs.

References: https://confluentinc.atlassian.net/browse/SEC-2896