### PR TITLE
Downgrade maven-surefire-plugin to 3.0.0-M4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>


### PR DESCRIPTION
Downgrading maven-surefire-plugin back to 3.0.0-M4. The previous upgrade to 3.0.0-M5 when building with jdk11 is causing issues with all SR PR builds to fail https://jenkins.confluent.io/job/Confluent%20Public%20Repo%20PR%20builder/job/schema-registry/job/PR-2129/1/console