### PR TITLE
Update confluent-log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
-        <confluent-log4j.version>1.2.17-cp2</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp2.2</confluent-log4j.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- Update to 2.0.0 for unit test patch usage -->


### PR DESCRIPTION
In order to fix log4j CVEs, confluent's fork of log4j was updated to version 1.2.17-cp2.2 and now needs to be included in all impacted patch releases branches. 

Once merged into 5.3.x, `pint merge` will update the version in all newer branches. (For 7.1.x and master, the confluent-log4j version will be 1.2.17-cp8, which includes the log redactor feature). 

References:
- https://confluentinc.atlassian.net/browse/SEC-2901