### PR TITLE
MMA-11603: Add centralized protobuf version from 5.3.x onwards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <confluent-log4j.version>1.2.17-cp2.2</confluent-log4j.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <protobuf.version>3.16.1</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.26</slf4j.version>


### PR DESCRIPTION
Jira ticket: https://confluentinc.atlassian.net/browse/MMA-11603

**ce-kafka**'s protobuf versions are updated to `3.16.1` from 5.3.x+ in:
- https://github.com/confluentinc/ce-kafka/pull/5442/files
- https://github.com/confluentinc/ce-kafka/pull/5457/files

**blueway** and **metadata-service** need to update the version as well. 

Therefore, adding centralized protobuf version in **common** that matches with ce-kafka's version. Blueway will inherit this version, and same could be done in metadata-service.

Note:
1. From `7.1.x`+, protobuf version is defined **common**: https://github.com/confluentinc/blueway/blob/ddfa26e4775e22e2110a2dabfa216d5292512db0/pom.xml#L64. Will be careful not to overwrite it when pint-merging. 
2. metadata-service only uses protobuf version in master. So it could directly use common's `${protobuf.version}`. Related PR: https://github.com/confluentinc/metadata-service/pull/864/files.
3. blueway's corresponding PR: https://github.com/confluentinc/blueway/pull/2376

Current versions in repo:
Confluent version| 5.3.x | 5.4.x | 5.5.x | 6.0.x | 6.1.x | 6.2.x | 7.0.x | 7.1.x | master
--- | --- | --- |--- |--- |--- |--- |--- |--- |---
ce-kafka | 3.4.0 | 3.8.0 | 3.11.4 | 3.11.4 | 3.11.4 | 3.11.4 | 3.17.3 | 3.17.3 | 3.17.3
blueway | 3.4.0 | 3.8.0 | 3.17.0 | 3.17.0 | 3.17.0 | 3.17.0 | 3.17.3 | `${protobuf.version}` (from common) | `${protobuf.version}` 
common | x | x | x | x | x | x | x | 3.17.3 | 3.17.3