### PR TITLE
chore: update protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.72.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <protobuf.version>3.17.3</protobuf.version>
+        <protobuf.version>3.19.4</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Update protobuf to 3.19.4 to address security advisory

See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569