### PR TITLE
chore: update maven-compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <kafka.scala.version>2.13</kafka.scala.version>
         <scala.version>2.13.5</scala.version>
         <maven-assembly.version>3.3.0</maven-assembly.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>


### PR DESCRIPTION
* improved error reporting with recent Java (16+) versions
* lots of other bugfixes

see release notes: https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.10.0