### PR TITLE
chore: update os-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
         <mockito.version>3.12.4</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
-        <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.73.Final</netty.version>


### PR DESCRIPTION
* fixes multi-threaded warnings when running parallel builds
  release notes: https://github.com/trustin/os-maven-plugin/releases/tag/os-maven-plugin-1.7.0