### PR TITLE
deprecate common-metrics

### DIFF
--- a/metrics/src/main/java/io/confluent/common/metrics/CompoundStat.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/CompoundStat.java
@@ -40,6 +40,7 @@ import java.util.List;
  * A compound stat is a stat where a single measurement and associated data structure feeds many
  * metrics. This is the example for a histogram which has many associated percentiles.
  */
+@Deprecated
 public interface CompoundStat extends Stat {
 
   public List<NamedMeasurable> stats();

--- a/metrics/src/main/java/io/confluent/common/metrics/JmxReporter.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/JmxReporter.java
@@ -57,6 +57,7 @@ import io.confluent.common.metrics.exceptions.MetricsException;
 /**
  * Register metrics in JMX as dynamic mbeans based on the metric names
  */
+@Deprecated
 public class JmxReporter implements MetricsReporter {
 
   private static final Logger log = LoggerFactory.getLogger(JmxReporter.class);

--- a/metrics/src/main/java/io/confluent/common/metrics/KafkaMetric.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/KafkaMetric.java
@@ -36,6 +36,7 @@ package io.confluent.common.metrics;
 
 import io.confluent.common.utils.Time;
 
+@Deprecated
 public final class KafkaMetric implements Metric {
 
   private MetricName metricName;

--- a/metrics/src/main/java/io/confluent/common/metrics/Measurable.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Measurable.java
@@ -33,6 +33,7 @@ package io.confluent.common.metrics;
 /**
  * A measurable quantity that can be registered as a metric
  */
+@Deprecated
 public interface Measurable {
 
   /**

--- a/metrics/src/main/java/io/confluent/common/metrics/MeasurableStat.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/MeasurableStat.java
@@ -40,6 +40,7 @@ package io.confluent.common.metrics;
  * {@link io.confluent.common.metrics.stats.Avg}, {@link io.confluent.common.metrics.stats.Max},
  * {@link io.confluent.common.metrics.stats.Count}, etc.
  */
+@Deprecated
 public interface MeasurableStat extends Stat, Measurable {
 
 }

--- a/metrics/src/main/java/io/confluent/common/metrics/Metric.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Metric.java
@@ -35,8 +35,11 @@
 package io.confluent.common.metrics;
 
 /**
+ * @deprecated use the equivalent class in org.apache.kafka.metrics instead
+ *
  * A numerical metric tracked for monitoring purposes
  */
+@Deprecated
 public interface Metric {
 
   /**

--- a/metrics/src/main/java/io/confluent/common/metrics/MetricConfig.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/MetricConfig.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Configuration values for metrics
  */
+@Deprecated
 public class MetricConfig {
 
   private Quota quota;

--- a/metrics/src/main/java/io/confluent/common/metrics/MetricName.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/MetricName.java
@@ -66,6 +66,7 @@ import io.confluent.common.utils.Utils;
  * sensor.record(messageSize);
  * }</pre>
  */
+@Deprecated
 public final class MetricName {
 
   private final String name;

--- a/metrics/src/main/java/io/confluent/common/metrics/Metrics.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Metrics.java
@@ -41,6 +41,8 @@ import io.confluent.common.utils.Time;
 import io.confluent.common.utils.Utils;
 
 /**
+ * @deprecated use the equivalent class in org.apache.kafka.metrics instead
+ *
  * A registry of sensors and metrics. <p> A metric is a named, numerical measurement. A sensor is a
  * handle to record numerical measurements as they occur. Each Sensor has zero or more associated
  * metrics. For example a Sensor might represent message sizes and we might associate with this
@@ -60,6 +62,7 @@ import io.confluent.common.utils.Utils;
  * sensor.record(messageSize);
  * </pre>
  */
+@Deprecated
 public class Metrics {
 
   private final MetricConfig config;

--- a/metrics/src/main/java/io/confluent/common/metrics/MetricsReporter.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/MetricsReporter.java
@@ -35,8 +35,11 @@ import java.util.List;
 import io.confluent.common.Configurable;
 
 /**
+ * @deprecated use the equivalent class in org.apache.kafka.metrics instead
+ *
  * A plugin interface to allow things to listen as new metrics are created so they can be reported.
  */
+@Deprecated
 public interface MetricsReporter extends Configurable {
 
   /**

--- a/metrics/src/main/java/io/confluent/common/metrics/Quota.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Quota.java
@@ -37,6 +37,7 @@ package io.confluent.common.metrics;
 /**
  * An upper or lower bound for metrics
  */
+@Deprecated
 public final class Quota {
 
   private final boolean upper;

--- a/metrics/src/main/java/io/confluent/common/metrics/QuotaViolationException.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/QuotaViolationException.java
@@ -40,6 +40,7 @@ import io.confluent.common.metrics.exceptions.MetricsException;
  * Thrown when a sensor records a value that causes a metric to go outside the bounds configured as
  * its quota
  */
+@Deprecated
 public class QuotaViolationException extends MetricsException {
 
   private static final long serialVersionUID = 1L;

--- a/metrics/src/main/java/io/confluent/common/metrics/Sensor.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Sensor.java
@@ -45,6 +45,7 @@ import io.confluent.common.utils.Utils;
  * #record(double)} api and would maintain a set of metrics about request sizes such as the average
  * or max.
  */
+@Deprecated
 public final class Sensor {
 
   private final Metrics registry;

--- a/metrics/src/main/java/io/confluent/common/metrics/Stat.java
+++ b/metrics/src/main/java/io/confluent/common/metrics/Stat.java
@@ -38,6 +38,7 @@ package io.confluent.common.metrics;
  * A Stat is a quanity such as average, max, etc that is computed off the stream of updates to a
  * sensor
  */
+@Deprecated
 public interface Stat {
 
   /**


### PR DESCRIPTION
Deprecating usage of common-metrics in favor of the equivalent classes in
org.apache.kafka.metrics since all platform components have already migrated.