### PR TITLE
AUDIT-971: Update confluent-log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <protobuf.version>3.19.4</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp8</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp9</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>


### PR DESCRIPTION
Logredactor v1.0.9 fixes the bug mentioned in AUDIT-971, which leads to a new version (1.2.17-cp9) for confluent-log4j(after bumping its logredactor dependency to v1.0.9)

References: https://confluentinc.atlassian.net/browse/AUDIT-971