### PR TITLE
AUDIT-986: Update confluent-log4j version for 7.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp9</confluent-log4j.version>
+        <confluent-log4j.version>1.2.17-cp10</confluent-log4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>


### PR DESCRIPTION
Logredactor v1.0.10 fixes the bug mentioned in AUDIT-986, which leads to a new version (1.2.17-cp10) for confluent-log4j(after bumping its logredactor dependency to v1.0.10)

References: https://confluentinc.atlassian.net/browse/AUDIT-986