### PR TITLE
DGS-3535: Upgrade maven-surefire-plugin version to 3.0.0-M6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M6</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>


### PR DESCRIPTION
The previous version of 3.0.0-M5 is causing some CI builds with JDK11 to fail during integration tests (example: [master in SR repo](https://jenkins.confluent.io/job/Confluent%20Public%20Repo%20PR%20builder/job/schema-registry/job/PR-2251/1/)). This is a [known issue](https://github.com/openzipkin/zipkin/issues/3159) in 3.0.0-M5 and is resolved in 3.0.0-M6.