### PR TITLE
KSECURITY-277: Fix for CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <jackson.version>2.10.2</jackson.version>
         <jackson.bom.version>2.10.2.20200130</jackson.bom.version>
 
-        <gson.version>2.8.5</gson.version>
+        <gson.version>2.9.0</gson.version>
         <guava.version>28.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <junit.version>4.13</junit.version>


### PR DESCRIPTION
Any version below 2.8.9 is vulnerable, so bumping it to 2.9.0. This will also keep it in line with what's currently in master.