### PR TITLE
Upgrade jackson bom, remove overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,13 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
-        <jackson.bom.version>2.13.2.20220324</jackson.bom.version>
-        <jackson.cbor.version>2.13.2</jackson.cbor.version>
+        <!--
+            Do not add additional jackson properties in this pom.
+            They should always be inherited from the bom. If a bump
+            is needed for a particular jackson module, update the
+            bom instead.
+        -->
+        <jackson.bom.version>2.13.2.20220328</jackson.bom.version>
 
         <gson.version>2.8.5</gson.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -234,23 +237,18 @@
                 <version>${gson.version}</version>
             </dependency>
 
-            <!-- Jackson artifacts with individual versioning -->
+            <!--
+                Do not add additional jackson dependencies in this pom.
+                They should always be inherited from the bom. If a bump
+                is needed for a particular jackson module, update the
+                bom instead.
+            -->
             <dependency>
               <groupId>com.fasterxml.jackson</groupId>
               <artifactId>jackson-bom</artifactId>
               <version>${jackson.bom.version}</version>
               <scope>import</scope>
               <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-cbor</artifactId>
-                <version>${jackson.cbor.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.databind.version}</version>
             </dependency>
             <!-- Kafka Deps -->
             <dependency>


### PR DESCRIPTION
A quick [github search](https://cs.github.com/?scopeName=All+repos&scope=&q=org%3Aconfluentinc+jackson.databind.version) shows that the only usage of `jackson.databind.version` is in connect repos that either override this property directly, or inherit from a connect parent pom that overrides this property. These should remain unaffected by removing these properties and dependency overrides.

Likely it's a separate effort to get connect to stop overriding these properties and dependency versions and instead inherit from common.