### PR TITLE
Bump `gson.version` to 2.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jackson.bom.version>2.13.2.20220324</jackson.bom.version>
         <jackson.cbor.version>2.13.2</jackson.cbor.version>
 
-        <gson.version>2.8.5</gson.version>
+        <gson.version>2.8.6</gson.version>
         <guava.version>30.1.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <junit.version>4.13</junit.version>


### PR DESCRIPTION
### What problem does this solve?
Control-Center tests are failing since `protobuf-java-util` got upgraded to `3.19.4` with following error message
```
 NoSuchMethod com.google.gson.JsonParser.parseReader
``` 
This is happening  because the upgraded `protobuf-java-util` is dependent on `gson` 2.8.6, but since we have `gson` 2.8.5 added as direct dependency coming from `common` it takes preference and hence throws above error. `2.8.5` [doesn't contain](https://javadoc.io/doc/com.google.code.gson/gson/2.8.5/index.html) parseReader method but [2.8.6 contains that.](https://javadoc.io/doc/com.google.code.gson/gson/2.8.6/com.google.gson/com/google/gson/JsonParser.html)

### What is the solution?
Bump `gson` version to 2.8.6

### Verification
Re-Ran test with bumped up version locally, Tests passing successfully.