### PR TITLE
chore: update maven dependency plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <scala.version>2.13.5</scala.version>
         <maven-assembly.version>3.3.0</maven-assembly.version>
         <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
         <maven-deploy.version>2.8.2</maven-deploy.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/MDEP-753 which has caused
issues in downstream repos in the past when enforcing dependency
declarations.