### PR TITLE
Upgrade surfire version to 3.0.0-M7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M6</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
         <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>


### PR DESCRIPTION
Follow up to https://github.com/confluentinc/common/pull/449 which broke ksqlDB build (cf. https://github.com/confluentinc/ksql/issues/9060).

After this PR is merged, we can address 9060 to "unpin" the version to -M5 for ksqlDB and use -M7. -- I did a trial PR for ksqlDB to verify that `-M7` actually works for us: https://github.com/confluentinc/ksql/pull/9200