### PR TITLE
APPSEC-1393:Migrate from confluent-log4j to reload4j [5.4.x -- 7.0.x]

### DIFF
--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -35,8 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,9 @@
         <protobuf.version>3.19.4</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
-        <slf4j.version>1.7.26</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp2.2</confluent-log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <reload4j.version>1.2.19</reload4j.version>
+        <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>
@@ -303,21 +304,8 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-                <exclusions>
-                    <!-- Use a repackaged version of log4j with security patches instead-->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <!-- Security patches to the end-of-life log4j 1.2.17 -->
-                <groupId>io.confluent</groupId>
-                <artifactId>confluent-log4j</artifactId>
-                <version>${confluent-log4j.version}</version>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>${slf4j-reload4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,11 @@
                 <version>${slf4j-reload4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${netty.version}</version>


### PR DESCRIPTION
This is to cherry-pick changes in 7.2.x (https://github.com/confluentinc/common/pull/450 and https://github.com/confluentinc/common/pull/451) to migrate confluent-log4j to reload4j.