### PR TITLE
APPSEC-1393: Confluent log4j to reload4j [7.1.x Only]

### DIFF
--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -40,12 +40,13 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <artifactId>logredactor</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -35,8 +35,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <artifactId>logredactor</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,14 @@
         <protobuf.version>3.19.4</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
-        <slf4j.version>1.7.30</slf4j.version>
-        <confluent-log4j.version>1.2.17-cp10</confluent-log4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <logredactor.version>1.0.10</logredactor.version>
+        <!-- Potentially used by downstream projects -->
+        <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
+        <reload4j.version>1.2.19</reload4j.version>
+        <logredactor.version>1.0.10</logredactor.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>
@@ -354,26 +358,13 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-                <exclusions>
-                    <!-- Use a repackaged version of log4j with security patches instead-->
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <!-- Security patches to the end-of-life log4j 1.2.17 -->
-                <groupId>io.confluent</groupId>
-                <artifactId>confluent-log4j</artifactId>
-                <version>${confluent-log4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j-reload4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.reload4j</groupId>
+                <artifactId>reload4j</artifactId>
+                <version>${reload4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>


### PR DESCRIPTION
This is to cherry-pick changes in 7.2.x (https://github.com/confluentinc/common/pull/450 and https://github.com/confluentinc/common/pull/451) to migrate confluent-log4j to reload4j.