### PR TITLE
APPSEC-1393: Fix dependency in disk-usage-agent [6.2 and 7.0]

### DIFF
--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -39,12 +39,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This is needed because https://github.com/confluentinc/common/pull/464 is from 5.4.x and does not have disk-usage-agent project (This is only from 6.2.x). So this change will only be applied to 6.2.x and 7.0.x. 