### PR TITLE
chore: Use https for repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
-        <url>http://confluent.io</url>
+        <url>https://confluent.io</url>
     </organization>
-    <url>http://confluent.io</url>
+    <url>https://confluent.io</url>
     <description>
         Common utilities, including metrics and config.
     </description>
@@ -148,14 +148,14 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
# what

Start from maven 3.8.1, maven blocks external HTTP repositories by default. We should use https link for repositories

# how

Modify `http` to `https` for repositories