### PR TITLE
fix checkstyle

### DIFF
--- a/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java
+++ b/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java
@@ -58,7 +58,8 @@ public class DiskUsage {
           String displayName = dir.replace("disk.", "");
           String volume = dirs.get(dir);
 
-          String objectName = String.format("io.confluent.caas:type=VolumeMetrics, service=%s, dir=%s", serviceName, displayName);
+          String objectName = String.format(
+              "io.confluent.caas:type=VolumeMetrics, service=%s, dir=%s", serviceName, displayName);
           ObjectName volumeMBeanName = new ObjectName(objectName);
 
           Volume volumeMBean = new Volume(volume);
@@ -67,7 +68,11 @@ public class DiskUsage {
           Set<ObjectInstance> instances = server.queryMBeans(new ObjectName(objectName), null);
           ObjectInstance instance = (ObjectInstance) instances.toArray()[0];
 
-          log.info("DiskUsage Agent: Registering object :" + instance.getObjectName() + " for class : " + instance.getClassName());
+          log.info("DiskUsage Agent: Registering object :"
+              + instance.getObjectName()
+              + " for class : "
+              + instance.getClassName()
+          );
 
           log.info("DiskUsage Agent: Ping " + volumeMBean.toString());
         }

--- a/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java
+++ b/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java
@@ -90,16 +90,16 @@ public class Volume implements VolumeMBean {
 
   @Override
   public String toString() {
-    return "Volume{" +
-        "store=" + store.toString() +
-        ", total=" + getTotal() +
-        ", used=" + getUsed() +
-        ", available=" + getAvailable() +
-        ", percentUsed=" + getPercentUsed() +
-        ", percentAvailable=" + getPercentAvailable() +
-        ", mountpoint='" + getMountpoint() + '\'' +
-        ", deviceName='" + getDeviceName() + '\'' +
-        '}';
+    return "Volume{"
+        + "store=" + store.toString()
+        + ", total=" + getTotal()
+        + ", used=" + getUsed()
+        + ", available=" + getAvailable()
+        + ", percentUsed=" + getPercentUsed()
+        + ", percentAvailable=" + getPercentAvailable()
+        + ", mountpoint='" + getMountpoint() + '\''
+        + ", deviceName='" + getDeviceName() + '\''
+        + '}';
   }
 
 }


### PR DESCRIPTION
Fixing below errors
```
 30861 [2022-07-27T19:49:25.071Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:93:22: '+' s       hould be on a new line. [OperatorWrap]
 30862 [2022-07-27T19:49:25.071Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:94:37: '+' s       hould be on a new line. [OperatorWrap]
 30863 [2022-07-27T19:49:25.071Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:95:33: '+' s       hould be on a new line. [OperatorWrap]
 30864 [2022-07-27T19:49:25.072Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:96:31: '+' s       hould be on a new line. [OperatorWrap]
 30865 [2022-07-27T19:49:25.072Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:97:41: '+' s       hould be on a new line. [OperatorWrap]
 30866 [2022-07-27T19:49:25.072Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:98:45: '+' s       hould be on a new line. [OperatorWrap]
 30867 [2022-07-27T19:49:25.072Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:99:55: '+' s       hould be on a new line. [OperatorWrap]
 30868 [2022-07-27T19:49:25.072Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:100:51: '+'        should be on a new line. [OperatorWrap]
 30869 [2022-07-27T19:49:25.073Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java:101:51: '+'        should be on a new line. [OperatorWrap]
 30870 [2022-07-27T19:49:25.073Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java:61: Line        is longer than 100 characters (found 130). [LineLength]
 30871 [2022-07-27T19:49:25.073Z] [ERROR] /home/jenkins/workspace/s_rs-start-stabilization-process/prod/common/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java:70: Line        is longer than 100 characters (found 131). [LineLength]
```