### PR TITLE
Surefire <useModulePath>false</useModulePath>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -727,6 +727,13 @@
                         <include>**/*IT.java</include>
                         <include>**/*ITCase.java</include>
                     </includes>
+                    <!--
+                    This is required when building with jdk 11 and failsafe 3.0.0-M5 when
+                      there is more than one test suite.
+                    With jdk 11, it wants to use fancy new jdk 9 "module" logic by default.
+                      see https://github.com/openzipkin/zipkin/issues/3159
+                    -->
+                    <useModulePath>false</useModulePath>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This is quite annoying, and a bunch of people are spending many hours re-discovering and fixing this indendently, so I wanted to fix it at the top:
https://cs.github.com/?q=org%3Aconfluentinc+useModulePath

You can tell this is unintuitive bc they all reference these random stackoverflows and github issues.