### PR TITLE
chore: switch to pinned nanoversion strategy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@ common {
     downStreamRepos = ["rest-utils", "ksql", "newwave",
         "kafka-connect-replicator", "hub-client"]
     nanoVersion = true
+    pinnedNanoVersions = true
     timeoutHours = 3
 }


### PR DESCRIPTION
## what

This PR add pinnedNanoVersions property, so that Jenkins will try to pin each version update in pom.xml instead of using version range.

e.g.
[7.3.0, 7.4.0) -> 7.3.0-99 after each build
![image](https://user-images.githubusercontent.com/13213562/192655953-26e429f6-9454-4871-8885-07488423f648.png)


## why

- better reproducible builds, mater branch won't follow latest upstream dependency because of version range
- branch become more stable since it will reject broken changes

That is brought up by Ksql team initially because they want to have better reproducible builds. And with that change, version bumps will only happen when the upstream build is compatible. That means the mater branch will be more stable and reject broken upstream changes.

noted: `<io.confluent.license-file-generator.version>` still use version range because that dependency only get pulled when using `-Pdocker` profile which CI does not use by default.


## context

https://confluentinc.atlassian.net/wiki/spaces/~453963977/pages/2809331888/One-Pager+Optional+Pinned-Deps+Nanoversion+Strategy
