### PR TITLE
APIF-2957: Upgrade Jackson and Protobuf versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,10 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.13.2</jackson.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
-        <jackson.bom.version>2.13.2.20220324</jackson.bom.version>
-        <jackson.cbor.version>2.13.2</jackson.cbor.version>
+        <jackson.version>2.13.4</jackson.version>
+        <jackson.databind.version>2.13.4.2</jackson.databind.version>
+        <jackson.bom.version>2.13.4.20221013</jackson.bom.version>
+        <jackson.cbor.version>2.13.4</jackson.cbor.version>
 
         <gson.version>2.9.0</gson.version>
         <guava.version>30.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.79.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <protobuf.version>3.19.4</protobuf.version>
+        <protobuf.version>3.19.6</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Upgrade Jackson to 2.13.4 and Protobuf to 3.19.6. 