### PR TITLE
fix: override maven version plugin's default versionrange

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
             the version ranges for kafka and ce-kafka. We want to run this for local builds,
             but disable this in the jenkins profile so it doesn't run during CI builds.
         -->
+        <versionRange>${confluent.version.range}</versionRange>
+        <!-- This is the version range used by resolver-maven-plugin to resolve the
+            version of ccs and ce-kafka. This allowed this property to be overridden
+            through cmd lines.
+        -->
         <skip.maven.resolver.plugin>false</skip.maven.resolver.plugin>
         <!-- The custom install step handles installing a modified pom file with the
             kafka version ranges resolved. We only do this for local builds so for 
@@ -806,7 +811,7 @@
                 <configuration>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-clients</artifactId>
-                    <versionRange>${confluent.version.range}</versionRange>
+                    <versionRange>${versionRange}</versionRange>
                     <newPomFile>${installed.pom.file}</newPomFile>
                     <skip>${skip.maven.resolver.plugin}</skip>
                     <failIfCCSNotfound>true</failIfCCSNotfound>

--- a/pom.xml
+++ b/pom.xml
@@ -137,14 +137,14 @@
             never be used any where else.
         -->
         <confluent.version.range>[6.1.10-0, 6.1.11-0)</confluent.version.range>
-        <!-- Controls whether we run the maven resolver plugin which is used to resolve
-            the version ranges for kafka and ce-kafka. We want to run this for local builds,
-            but disable this in the jenkins profile so it doesn't run during CI builds.
-        -->
-        <versionRange>${confluent.version.range}</versionRange>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.
+        -->
+        <versionRange>${confluent.version.range}</versionRange>
+        <!-- Controls whether we run the maven resolver plugin which is used to resolve
+            the version ranges for kafka and ce-kafka. We want to run this for local builds,
+            but disable this in the jenkins profile so it doesn't run during CI builds.
         -->
         <skip.maven.resolver.plugin>false</skip.maven.resolver.plugin>
         <!-- The custom install step handles installing a modified pom file with the


### PR DESCRIPTION
# what

Currently, we can not override `resolver-maven-plugin`'s default versionRange through cmd lines except changing `confluent.version.range`. However `confluent.version.range` will be used in other places to resolve versions as well.

# how

Add a new parameter `versionRange` that can be overrode through cmd lines. So that we can change `resolver-maven-plugin`'s default versionRange without affecting `confluent.version.range`