### PR TITLE
Update logredactor depdendency to 1.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,12 @@
         <!-- Update to 2.0.0 for unit test patch usage -->
         <powermock.version>2.0.0</powermock.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <logredactor.version>1.0.10</logredactor.version>
+        <logredactor.version>1.0.11</logredactor.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.19</reload4j.version>
-        <logredactor.version>1.0.10</logredactor.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>


### PR DESCRIPTION
Logredactor version 1.0.10 included a stray repo which does not exist.  Maven sometimes can timeout looking for this repo. 

This PR bumps the dependency to the version which fixes this issue.