### PR TITLE
Return the original "version_range" if it isn't an actual Maven version range

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -73,6 +73,10 @@ class CI:
 
     def resolve_version_range(self, version_range, print_method):
         """Run the custom maven resolver plugin to find the latest artifact version in the range."""
+        if not self.is_version_range(version_range):
+            log.info("Specified version is not a range: {}".format(version_range))
+            return version_range
+
         # We just use one of the kafka artifacts to resolve the range. No particular reason for using this artifact.
         group_id = "org.apache.kafka"
         artifact_id = "kafka-clients"
@@ -108,6 +112,11 @@ class CI:
 
         log.error("Failed to resolve the version range.")
         sys.exit(1)
+
+    def is_version_range(self, version):
+        """Checks if the specified Maven version is a range"""
+        return (version.startsWith('[') or version.startsWith(')')) and
+            (version.endsWith(']') or version.endsWith(')'))
 
     def run_cmd(self, cmd, return_stdout=False):
         """Execute a shell command. Return true if successful, false otherwise."""

--- a/ci.py
+++ b/ci.py
@@ -99,7 +99,7 @@ class CI:
         cmd += "-Dprint{} -q".format(print_method)
         log.info("Resolving the version range for: {}".format(version_range))
         result, stdout = self.run_cmd(cmd, return_stdout=True)
-  
+
         if result:
             # When run from Jenkins there will be additional output included so we just get the last line of output.
             version = stdout.strip().splitlines()[-1]
@@ -115,8 +115,8 @@ class CI:
 
     def is_version_range(self, version):
         """Checks if the specified Maven version is a range"""
-        return (version.startsWith('[') or version.startsWith('(')) and
-            (version.endsWith(']') or version.endsWith(')'))
+        return (version.startswith('[') or version.startswith('(')) and \
+            (version.endswith(']') or version.endswith(')'))
 
     def run_cmd(self, cmd, return_stdout=False):
         """Execute a shell command. Return true if successful, false otherwise."""

--- a/ci.py
+++ b/ci.py
@@ -115,7 +115,7 @@ class CI:
 
     def is_version_range(self, version):
         """Checks if the specified Maven version is a range"""
-        return (version.startsWith('[') or version.startsWith(')')) and
+        return (version.startsWith('[') or version.startsWith('(')) and
             (version.endsWith(']') or version.endsWith(')'))
 
     def run_cmd(self, cmd, return_stdout=False):


### PR DESCRIPTION
Run on PR branch (derives from `6.1.x`):

```
$ python ./ci.py "anything goes" `pwd`
Running additional version updates for common
Resolving the version range for ccs kafka.
Getting version range for: kafka.version.
Version range for kafka.version is: [6.1.10-0-ccs, 6.1.11-0-ccs)
Resolving the version range for: [6.1.10-0-ccs, 6.1.11-0-ccs)
mvn --batch-mode -Pjenkins io.confluent:resolver-maven-plugin:0.6.0:resolve-kafka-range -DgroupId=org.apache.kafka -DartifactId=kafka-clients -DversionRange="[6.1.10-0-ccs, 6.1.11-0-ccs)" -Dskip.maven.resolver.plugin=false -DprintCCS -q
6.1.10-10-ccs

Resolved the version range to version: 6.1.10-10-ccs
Setting the property kafka.version to 6.1.10-10-ccs
mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=kafka.version -DnewVersion=6.1.10-10-ccs
...
Finished setting the property.
Finished resolving the version range for ccs kafka.
Resolving the version range for ce kafka.
Getting version range for: ce.kafka.version.
Version range for ce.kafka.version is: [6.1.10-0-ce, 6.1.11-0-ce)
Resolving the version range for: [6.1.10-0-ce, 6.1.11-0-ce)
mvn --batch-mode -Pjenkins io.confluent:resolver-maven-plugin:0.6.0:resolve-kafka-range -DgroupId=org.apache.kafka -DartifactId=kafka-clients -DversionRange="[6.1.10-0-ce, 6.1.11-0-ce)" -Dskip.maven.resolver.plugin=false -DprintCE -q
6.1.10-10-ce

Resolved the version range to version: 6.1.10-10-ce
Setting the property ce.kafka.version to 6.1.10-10-ce
mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=ce.kafka.version -DnewVersion=6.1.10-10-ce
...
Finished setting the property.
Finished resolving the version range for ce kafka.
Finished all common additional version updates.
```

And resulting diff:

```
diff --git a/pom.xml b/pom.xml
index d08aa0505..c2ced2a6a 100644
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <argLine></argLine>
         <avro.version>1.9.2</avro.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[6.1.10-0-ccs, 6.1.11-0-ccs)</kafka.version>
-        <ce.kafka.version>[6.1.10-0-ce, 6.1.11-0-ce)</ce.kafka.version>
+        <kafka.version>6.1.10-10-ccs</kafka.version>
+        <ce.kafka.version>6.1.10-10-ce</ce.kafka.version>
         <easymock.version>4.0.1</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
```

Running again (after committing locally) to simulate running from a version-tagged commit:

```
python ./ci.py "anything goes" `pwd`
Running additional version updates for common
Resolving the version range for ccs kafka.
Getting version range for: kafka.version.
Version range for kafka.version is: 6.1.10-10-ccs
Specified version is not a range: 6.1.10-10-ccs
Setting the property kafka.version to 6.1.10-10-ccs
mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=kafka.version -DnewVersion=6.1.10-10-ccs
...
Finished setting the property.
Finished resolving the version range for ccs kafka.
Resolving the version range for ce kafka.
Getting version range for: ce.kafka.version.
Version range for ce.kafka.version is: 6.1.10-10-ce
Specified version is not a range: 6.1.10-10-ce
Setting the property ce.kafka.version to 6.1.10-10-ce
mvn --batch-mode versions:set-property -DgenerateBackupPoms=false -Dproperty=ce.kafka.version -DnewVersion=6.1.10-10-ce
...
Finished setting the property.
Finished resolving the version range for ce kafka.
Finished all common additional version updates.
```

And there was no change to the `pom.xml` (as expected).