### PR TITLE
add snakeyaml to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <reload4j.version>1.2.19</reload4j.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>
@@ -166,6 +167,17 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf.version}</version>
+            </dependency>
+            <!-- snakeyaml is brought in by several confluent libraries
+                 as "provided" dependency, thus leading to usage of
+                 outdated versions. This instructs projects using this pom
+                 to use this snakeyaml version, unless otherwise overriden.
+                 After this change, we should remove all the snakeyaml re-definitions
+                 in other Confluent repositories. -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Snakeyaml is a dependency that is brought in by multiple confluent libraries in scope "provided" that leads to unexpected, old versions of snakeyaml showing up across built projects that do not override the version. 
Adding the snakeyaml to DependencyManagment instructs projects using common to use this version of snakeyaml when resolving transitive dependencies and should hopefully resolve our woes with this library. 
After merging and testing, we should purge per-project pinning of this library. 
remove here:
https://github.com/confluentinc/schema-registry/blob/master/pom.xml#L160
https://github.com/confluentinc/kafka-rest/blob/master/pom.xml#L131
https://github.com/confluentinc/schroedinger/blob/master/pom.xml#L85 (just version definition) 
https://github.com/confluentinc/cc-kafka-healthcheck/blob/master/pom.xml#L22
revert this:
https://github.com/confluentinc/ce-kafka/commit/df54f8fccb09d011d00c0eb92adcc448bd220939