### PR TITLE
APPSEC-2551: Update Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,10 @@
         <spotbugs.version>3.1.12</spotbugs.version>
         <spotbugs.maven.plugin.version>3.1.12</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson.databind.version>2.13.4.2</jackson.databind.version>
-        <jackson.bom.version>2.13.4.20221013</jackson.bom.version>
-        <jackson.cbor.version>2.13.4</jackson.cbor.version>
+        <jackson.version>2.14.2</jackson.version>
+        <jackson.databind.version>2.14.2</jackson.databind.version>
+        <jackson.bom.version>2.14.2</jackson.bom.version>
+        <jackson.cbor.version>2.14.2</jackson.cbor.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>30.1.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>


### PR DESCRIPTION
An update of SnakeYaml to version 2.0 revealed incompatibility with Jackson < 2.14.2. Updating Jackson to 2.14.2 that was shown working with SnakeYaml 2.0 in https://github.com/confluentinc/cc-pipeline-service/pull/1153