### PR TITLE
APPSEC-2551: Update Prometheus JMX Exporter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.9</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>
-        <jmx_prometheus_javaagent.version>0.17.2</jmx_prometheus_javaagent.version>
+        <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.6.2</jolokia-jvm.version>
         <checkstyle.version>8.44</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Updating JMX Prometheus as the old version brings shaded SnakeYaml 1.33 vulnerable to CVE-2022-1471