### PR TITLE
add dependency management to match versions in ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,7 @@
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.14.2</jackson.version>
-        <jackson.databind.version>2.14.2</jackson.databind.version>
-        <jackson.bom.version>2.14.2</jackson.bom.version>
-        <jackson.cbor.version>2.14.2</jackson.cbor.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>30.1.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
@@ -95,6 +93,7 @@
         <logredactor.version>1.0.12</logredactor.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
+        <snappy.version>1.1.10.1</snappy.version>
         <zkclient.version>0.11</zkclient.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <bouncycastle.version>1.68</bouncycastle.version>
@@ -184,6 +183,22 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
+            <!-- Unify jetty across CP, remove jetty definition from
+            rest-utils after this goes through -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- snappy-java is brought in by kafka-clients and its version is specified
+            in ce-kafka -->
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.10.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -256,7 +271,7 @@
             <dependency>
               <groupId>com.fasterxml.jackson</groupId>
               <artifactId>jackson-bom</artifactId>
-              <version>${jackson.bom.version}</version>
+              <version>${jackson.version}</version>
               <scope>import</scope>
               <type>pom</type>
             </dependency>
@@ -271,16 +286,6 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
                 <version>${scala.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-cbor</artifactId>
-                <version>${jackson.cbor.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.databind.version}</version>
             </dependency>
             <!-- Kafka Deps -->
             <dependency>


### PR DESCRIPTION
Adding jetty and snappy to dependency management to match the versions used in ce-kafka and avoid maven builds imports with incorrect versions. e.g., bringing in kafka-clients of licensing with outdated jetty / snappy / jose