### PR TITLE
pin jose4j version to match ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <java.version>8</java.version>
         <jackson.version>2.14.2</jackson.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
+        <jose4j.version>0.9.3</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>30.1.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
@@ -198,6 +199,13 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>1.1.10.1</version>
+            </dependency>
+            <!-- jose4j is used in ce-kafka and its version is sepcified
+            in ce-kafka, this is for maven projects to use the correct version -->
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Jose4j is used by several ce-kafka components used by maven built projects. This guarantees that the updated version of the component is being used. 