### PR TITLE
update jackson to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <spotbugs.version>4.0.2</spotbugs.version>
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <jose4j.version>0.9.3</jose4j.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
This is to unify jackson databind across the board. Update fails downstream validation for ksql. 