### PR TITLE
APPSEC-2796: add guava to dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,13 @@
                 <artifactId>jose4j</artifactId>
                 <version>${jose4j.version}</version>
             </dependency>
+            <!-- we define guava version above, its version is specified
+            in ce-kafka, this is for maven projects to use the correct version -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
In addition to version definition, add guava to the dependencyManagement section to make sure that correct version of guava is used by maven projects importing ce-kafka libraries. 