### PR TITLE
APPSEC-3039: Update jetty and netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.14.2</jackson.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.52.v20230823</jetty.version>
         <jose4j.version>0.9.3</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
@@ -84,7 +84,7 @@
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>3.19.6</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->


### PR DESCRIPTION
Update jetty to 9.4.52.v20230823 to address: CVE-2023-40167 and CVE-2023-41900
Update netty to 4.1.94 to address: CVE-2023-34462