### PR TITLE
Upgrade protobuf to 3.24.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.100.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <protobuf.version>3.19.6</protobuf.version>
+        <protobuf.version>3.24.4</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
Upgrade to protobuf 3.24.4  .  One of the dependencies of Schema Registry requires 3.22+, we are currently on 3.19.6