### PR TITLE
disable retirejs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1127,6 +1127,7 @@
                         <format>xml</format>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+                        <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
### What

RetireJS (a plugin dependency consumed by dependency-check that we use) is causing issues with builds. Examples: 
- https://semaphore.ci.confluent.io/jobs/bae63f70-ccdb-412c-9c9c-0eabc9305626
- https://jenkins.confluent.io/job/confluentinc/job/metadata-service/job/7.5.x/411/console

```
[ERROR] 	InitializationException: Failed to initialize the RetireJS repo: `/tmp/dctemp772c4170-e777-4d8b-bb31-6af8dfbccdf2/jsrepository.json` appears to be malformed. Please delete the file or run the dependency-check purge command and re-try running dependency-check.02:49
[ERROR] 		caused by JSONException: No value for info
```

This is blocking builds and a [known issue](https://github.com/RetireJS/retire.js/issues/423), rather than waiting for a fix we can disable it for the time being by adding the ```
<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>``` parameter

### Testing
We copied the dependency-check profile to this [repo's](https://github.com/confluentinc/metadata-service/pull/1959/files) pom.xml, built it as is, and the build failed with the error above. Then added this parameter ```<retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>``` and the build passed that stage
