### PR TITLE
Revert "disable retirejs"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1127,7 +1127,6 @@
                         <format>xml</format>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
-                        <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
### Description
The retire.js [issue](https://github.com/RetireJS/retire.js/issues/423) is fixed, we can re-enable that plugin. 

More context in this PR: https://github.com/confluentinc/common/pull/559

This reverts commit 9862a1ce73064e8e4ce60a371f2c141aabdcbaff.

### Testing
Created this sample PR: https://github.com/confluentinc/metadata-service/pull/1960

Last week it failed with `[ERROR] Exception occurred initializing RetireJS Analyzer.`, today the [workflow](https://jenkins.confluent.io/job/confluentinc-pr/job/metadata-service/view/change-requests/job/PR-1960/) succeeded even after enabling retire.js 