### PR TITLE
update zookeeper component to match version in ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.5</snappy.version>
         <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.5.9</zookeeper.version>
+        <zookeeper.version>3.8.3</zookeeper.version>
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>


### PR DESCRIPTION
In the process of mitigating Zookeeper CVE we need to update it both in ce-kafka as well as in common so the correct version is used by maven built projects. 