### PR TITLE
APPSEC-xyz: exclude logback-core and logback-classic 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,14 @@
                         <groupId>io.netty</groupId>
                         <artifactId>netty-transport-native-epoll</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR removes logback logging facility removed in ce/ccs kafka as well as kafka-rest. 
This PR resolves:  CVE-2023-6378 