### PR TITLE
exclude logback-core and logback-classic in line with the changes in kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,14 @@
                         <groupId>io.netty</groupId>
                         <artifactId>netty-transport-native-epoll</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
Excluding logback-core from zookeeper. 
This is second PR based at 6.1.x. First merge errorornously only was merged into master. 