### PR TITLE
Remove kafka-connect-replicator that is removed from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 
 common {
     slackChannel = '#kafka-warn'
-    downStreamRepos = ["rest-utils", "ksql", "newwave",
-        "kafka-connect-replicator", "hub-client"]
+    downStreamRepos = ["rest-utils", "ksql", "newwave", "hub-client"]
     nanoVersion = true
 }


### PR DESCRIPTION
As title said, the repo is moved to Semaphore permanently.