### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # See go/codeowners - automatically generated for confluentinc/common:
-*	@confluentinc/kafka-eng
-*	@confluentinc/security
+*	@confluentinc/kafka-eng @confluentinc/security


### PR DESCRIPTION
Previously, security would always override kafka-eng. Now, both are treated as codeowners.