### PR TITLE
Upgrade EasyMock version to be compatible with Jdk 17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>7.3.0-ccs</kafka.version>
         <ce.kafka.version>7.3.0-ce</ce.kafka.version>
-        <easymock.version>4.3</easymock.version>
+        <easymock.version>5.2.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>


### PR DESCRIPTION
The version of easymock in 7.3.x branch is 5.2.0 while all 7.3.x-post branches are 4.3.

EasyMock version 4.3 isn't compatible with Jdk 17 (used in Semaphore) so upgrading it. As far as compatibility issue concern, as EasyMock 5.2.0 is used in branch 7.3.x already, it should not be a problem.