### PR TITLE
fix: no implicit activation of docker-arm profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1365,11 +1365,6 @@
         </profile>
         <profile>
             <id>docker-arm</id>
-            <activation>
-                <property>
-                    <name>env.DOCKER_HOST</name>
-                </property>
-            </activation>
 
             <properties>
                 <ALLOW_UNSIGNED>true</ALLOW_UNSIGNED>


### PR DESCRIPTION
docker-arm profile should not be implicitly activated based on environment variables, otherwise it will break CI pipelines.