### PR TITLE
Add kafka-connect-hdfs as a downstream repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@
 
 common {
     slackChannel = '#kafka-warn'
-    downStreamRepos = ["rest-utils", "ksql", "newwave", "hub-client"]
+    downStreamRepos = ["rest-utils", "ksql", "newwave", "hub-client", "kafka-connect-hdfs"]
     nanoVersion = true
 }


### PR DESCRIPTION
Adds kafka-connect-hdfs as a downstream repo of confluentinc/common.
This step is necessary to facilitate the migration from Jenkins to Semaphore for confluentinc/kafka-connect-hdfs.
Ref: [link](https://confluentinc.atlassian.net/wiki/spaces/CONNECT/pages/3232666429/Jenkins+to+Semaphore+Migration+-+Connect#:~:text=Applicable%20for%20only,Jenkinsfile%23L5.)