### PR TITLE
CVE-2024-23944: Bump Zookeeper to 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <reload4j.version>1.2.25</reload4j.version>
         <logredactor.version>1.0.12</logredactor.version>
         <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>


### PR DESCRIPTION
ZK 3.8.3, which is used here, has a vulnerability in it, https://avd.aquasec.com/nvd/2024/cve-2024-23944/.

This bumps the version to 3.8.4, where it is fixed.