### PR TITLE
Downgrade jetty package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
         <jackson.version>2.14.2</jackson.version>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <jose4j.version>0.9.5</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>


### PR DESCRIPTION
Downgrade jetty to `9.4.53`. The new version upgrade recently in #582 affects DoS filtering in `rest-utils` jetty server.

`rest-utils` changes: https://github.com/confluentinc/rest-utils/pull/478