### PR TITLE
MINOR: Bumping protobuf version to 3.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.100.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <protobuf.version>3.24.4</protobuf.version>
+        <protobuf.version>3.25.1</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
Why?

----

Bumping the `protobuf.version` 3.25.1 to match ce-kafka: https://github.com/confluentinc/ce-kafka/blob/d5268708e08e1528abee555d5a74073d7f063e81/gradle/dependencies.gradle#L206