### PR TITLE
APPSEC-4033: update zookeeeper to 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.5</snappy.version>
         <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>


### PR DESCRIPTION
This is continuation of https://github.com/confluentinc/common/pull/589 that applied the update to the master branch only