### PR TITLE
Update bouncycastle version to 1.78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <zookeeper.version>3.8.4</zookeeper.version>
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
-        <bouncycastle.jdk18.version>1.78.1</bouncycastle.jdk18.version>
+        <bouncycastle.jdk18.version>1.78</bouncycastle.jdk18.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.6.2</jolokia-jvm.version>
         <checkstyle.version>8.44</checkstyle.version>


### PR DESCRIPTION
bcprov-ext-jdk18on 1.78.1 doesn't seem to be published in [mvnrepository](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-ext-jdk18on). Same for [maven central](https://central.sonatype.com/artifact/org.bouncycastle/bcprov-ext-jdk18on/versions). The [release page](https://www.bouncycastle.org/latest_releases.html) seems to imply that -ext- versions should be there too.

This PR updates the bouncycastle version to 1.78 since it is a published version.

https://confluent.slack.com/archives/C05G3CNGLF9/p1714761258647209?thread_ts=1714742333.550519&cid=C05G3CNGLF9