### PR TITLE
CCMSG-2462: netty-bom version should be picked up from `netty.version` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.100.Final</version>
+                <version>${netty.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Problem
Downstream projects, like [newwave](https://github.com/confluentinc/newwave), designate `netty-all:${netty.version}` as a dependency. However, the dependencies sourced from `netty-all` share versions defined by `netty-bom` in the common pom.

### Example:
```
In newwave repo:
> mvn dependency:tree
...
+- io.netty:netty-all:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-dns:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-haproxy:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-memcache:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-mqtt:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-redis:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-smtp:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-socks:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-stomp:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-codec-xml:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-native-unix-common:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-handler-ssl-ocsp:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-resolver:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-resolver-dns:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-rxtx:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-sctp:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-udt:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-classes-epoll:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-classes-kqueue:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-resolver-dns-classes-macos:jar:4.1.100.Final:compile
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.100.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-riscv64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.100.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.100.Final:runtime
[INFO] |  +- io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.100.Final:runtime
[INFO] |  \- io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.100.Final:runtime
...
```

## Solution
Enforce the version of netty-bom to be equal to the value defined in `netty.version` property

## Testing
Verification done on local machine: 
```
In confluentinc/common
> mvn clean install

In confluentinc/newwave, 
> mvn dependency:tree
+- io.netty:netty-all:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-dns:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-haproxy:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-memcache:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-mqtt:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-redis:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-smtp:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-socks:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-stomp:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-codec-xml:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-native-unix-common:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-handler-ssl-ocsp:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-resolver:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-resolver-dns:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-rxtx:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-sctp:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-udt:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-classes-epoll:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-classes-kqueue:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-resolver-dns-classes-macos:jar:4.1.108.Final:compile
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-riscv64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.108.Final:runtime
[INFO] |  +- io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.108.Final:runtime
[INFO] |  \- io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.108.Final:runtime
```