### PR TITLE
CPBR-1182: add pluginRepository for non common-parent child

### DIFF
--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -77,4 +77,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
             </plugin>
         </plugins>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -46,4 +46,11 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
To upload jars to S3 bucket for CP releases which ultimately are accessible by customers at https://packages.confluent.io/maven/ , CPBR is using a new maven plugin which is released on https://packages.confluent.io/maven/ also. So to download that plugin without modifying ~/.m2/settings.xml file on customer's end, this PR adds that in the pom.xml.