### PR TITLE
add version definitions of bouncycastle fips dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.78</bouncycastle.jdk18.version>
+        <bouncycastle.fips.version>1.0.2.5</bouncycastle.fips.version>
+        <bouncycastle.tls-fips.version>1.0.1.9</bouncycastle.tls-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>8.44</checkstyle.version>
@@ -344,6 +346,16 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.jdk18.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bc-fips</artifactId>
+                <version>${bouncycastle.fips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bctls-fips</artifactId>
+                <version>${bouncycastle.tls-fips.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <bouncycastle.jdk18.version>1.78</bouncycastle.jdk18.version>
         <bouncycastle.fips.version>1.0.2.5</bouncycastle.fips.version>
         <bouncycastle.tls-fips.version>1.0.1.9</bouncycastle.tls-fips.version>
+        <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>8.44</checkstyle.version>
@@ -356,6 +357,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bctls-fips</artifactId>
                 <version>${bouncycastle.tls-fips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-fips</artifactId>
+                <version>${bouncycastle.bcpkix-fips.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
We need to synchronize versions of bouncycastle fips libraries with versions used in ce-kafka. 
The addition of the libraries to dependencyMagament section does  **not** automatically include them in the projects, just specifies which version to use if the project pulls it e.g. transitively. 