### PR TITLE
add correct version of tls_fips

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.78</bouncycastle.jdk18.version>
         <bouncycastle.fips.version>1.0.2.5</bouncycastle.fips.version>
-        <bouncycastle.tls-fips.version>1.0.1.9</bouncycastle.tls-fips.version>
+        <bouncycastle.tls-fips.version>1.0.19</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>


### PR DESCRIPTION
bouncycastle-tls-fips version added in #614 was incorrect. This remediates that issue. 