### PR TITLE
update jackson to match ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <spotbugs.version>4.7.1</spotbugs.version>
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
         <java.version>8</java.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
         <jetty.version>9.4.54.v20240208</jetty.version>
         <jose4j.version>0.9.5</jose4j.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
This PR updated jackson libraries in common to match version in ce-kafka 7.7.x
This will likely break things as we experience before when applying to earlier version of common