### PR TITLE
Remove dependency-check-maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1204,42 +1204,6 @@
             </activation>
             <build>
               <plugins>
-                <plugin>
-                    <groupId>org.owasp</groupId>
-                    <artifactId>dependency-check-maven</artifactId>
-                    <version>${dependency.check.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>io.confluent</groupId>
-                            <artifactId>build-tools</artifactId>
-                            <version>${io.confluent.common.version}</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <suppressionFiles>
-                            <suppressionFile>${dependency.check.suppressions.location}</suppressionFile>
-                        </suppressionFiles>
-                        <cveUrlModified>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools-891377121322-us-west-2/nvd.nist.gov/nvdcve-1.1-modified.json.gz</cveUrlModified>
-                        <cveUrlBase>https://s3-us-west-2.amazonaws.com/confluent-packaging-tools-891377121322-us-west-2/nvd.nist.gov/nvdcve-1.1-%d.json.gz</cveUrlBase>
-                        <!-- Don't use this except in special circumstances as a way to disable this check on the command
-                             line. Downstream projects should all be running this as part of their normal builds and should
-                             not override this flag in their pom file. -->
-                        <skip>${dependency.check.skip}</skip>
-                        <skipSystemScope>true</skipSystemScope>
-                        <skipProvidedScope>true</skipProvidedScope>
-                        <skipTestScope>true</skipTestScope>
-                        <format>xml</format>
-                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
                </plugins>
             </build>
         </profile>


### PR DESCRIPTION
This removes the `dependency-check-maven` plugin from `pom.xml`. This plugin was once upon a time used by AppSec supposedly, but it is no longer used.