### PR TITLE
add cc-cluster-upgrader as downstream

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -10,7 +10,7 @@ semaphore:
   nano_version: true
   extra_deploy_args: "-Pjenkins"
   extra_build_args: "-Pjenkins"
-  downstream_projects: ["rest-utils", "ksql", "newwave", "kafka-connect-replicator", "hub-client"]
+  downstream_projects: ["rest-utils", "ksql", "newwave", "kafka-connect-replicator", "hub-client", "cc-cluster-upgrader"]
 git:
   enable: true
 code_artifact:


### PR DESCRIPTION
added so that upgrader's common-parent version stays up to date