### PR TITLE
APPSEC-4297: update classgraph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
         <avro.version>1.11.3</avro.version>
+        <classgraph.version>4.8.138</classgraph.version>
         <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
         <azure-identity.version>1.11.4</azure-identity.version>
         <azure-storage.version>12.25.4</azure-storage.version>
@@ -218,6 +219,14 @@
               <groupId>org.apache.avro</groupId>
               <artifactId>avro</artifactId>
               <version>${avro.version}</version>
+            </dependency>
+            <!-- Pin the classgraph version to match version used in ce-kafka
+            the outadated version is brought by schema-registry transitive
+            dependency mbknor-jackson -->
+            <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${classgraph.version}</version>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>


### PR DESCRIPTION
Pin the version of classgraph as an outdated version is brought in as a transitive dependency of mbknor-jackson. 