### PR TITLE
downgrade fips library to a version that is certified compliant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,11 @@
         <!-- remove the bouncycastle.version after all downstream repos are updated -->
         <bouncycastle.version>1.70</bouncycastle.version>
         <bouncycastle.jdk18.version>1.78</bouncycastle.jdk18.version>
-        <bouncycastle.fips.version>1.0.2.5</bouncycastle.fips.version>
-        <bouncycastle.tls-fips.version>1.0.19</bouncycastle.tls-fips.version>
+        <!-- before updating bouncycastle.fips.version make sure
+        that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK
+        as of -->
+        <bouncycastle.fips.version>1.0.2.4</bouncycastle.fips.version>
+        <bouncycastle.tls-fips.version>1.0.13</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>


### PR DESCRIPTION
Upgrade of bouncycastle fips library caused incompatibility issues discovered late in testing. We need to roll back to the last certified version and match the library versions with ce-kafka. 