### PR TITLE
Remove upgrader from service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -10,7 +10,7 @@ semaphore:
   nano_version: true
   extra_deploy_args: "-Pjenkins"
   extra_build_args: "-Pjenkins"
-  downstream_projects: ["rest-utils", "ksql", "newwave", "kafka-connect-replicator", "hub-client", "cc-cluster-upgrader"]
+  downstream_projects: ["rest-utils", "ksql", "newwave", "kafka-connect-replicator", "hub-client"]
 git:
   enable: true
 code_artifact:


### PR DESCRIPTION
Remove cc-cluster-upgrader from downstream projects to fix the bug that caused infinite version bump loop on CI.