### PR TITLE
[RCCA-21560] remove dependency with missing version definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,11 +362,6 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.jdk18.version}</version>
             </dependency>


### PR DESCRIPTION
bouncycastle.version is no longer defined, consequently we should have no dependency management reffering to it