### PR TITLE
Bump protobuf version to 3.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.108.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <protobuf.version>3.24.4</protobuf.version>
+        <protobuf.version>3.25.4</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
The previous version 3.24 ended support 11/2023