### PR TITLE
[rcca-22120] proper revert of bc update to avoid naming conflicts in downstream repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
         <!-- before updating bouncycastle.fips.version make sure
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK
         as of -->
-        <bouncycastle.bc-fips.version>1.0.2.4</bouncycastle.bc-fips.version>
-        <bouncycastle.bctls-fips.version>1.0.13</bouncycastle.bctls-fips.version>
+        <bouncycastle.fips.version>1.0.2.4</bouncycastle.fips.version>
+        <bouncycastle.tls-fips.version>1.0.13</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
         <!-- Bouncycastle update to version 2.0 This will have to be applied all .x branches,
         here for FedRAMP builds -->
@@ -394,12 +394,12 @@
              <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bc-fips</artifactId>
-                <version>${bouncycastle.bc-fips.version}</version>
+                <version>${bouncycastle.fips.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bctls-fips</artifactId>
-                <version>${bouncycastle.bctls-fips.version}</version>
+                <version>${bouncycastle.tls-fips.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
proper revert of bouncycastle update