### PR TITLE
CPBR-1680: adding cp-jar-build ci gating

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,6 +61,32 @@ blocks:
             - mvn -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
 
+  - name: CP Jar Build CI Gating
+    dependencies: [ ]
+    run:
+      # Run this block only for pull requests
+      when: "pull_request =~ '.*'"
+    task:
+      env_vars:
+        - name: COMPONENT_NAME
+          value: common
+      jobs:
+        - name: Trigger and wait for CP Jar Build Task
+          commands:
+            # Don't run this block if target branch for PR is not a nightly branch or master branch
+            # cp-jar-build today doesn't support other branches
+            - |
+              if [[ "$SEMAPHORE_GIT_BRANCH" =~ ^[0-9]+\.[0-9]+\.x$ ]] || [[ "$SEMAPHORE_GIT_BRANCH" == "master" ]] ; then \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is CP nightly or master branch. Triggering cp-jar-build task."; \
+                  sem-trigger -p packaging \
+                    -t cp-jar-build \
+                    -b $SEMAPHORE_GIT_BRANCH \
+                    -d "|" -i "CUSTOM_BRANCH_COMPONENTS|${COMPONENT_NAME}=${SEMAPHORE_GIT_WORKING_BRANCH}" \
+                    -w; \
+              else \
+                  echo "PR is targeted to ${SEMAPHORE_GIT_BRANCH} branch which is not CP nightly or master branch. Skipping cp-jar-build task."; \
+              fi;
+
 after_pipeline:
   task:
     agent:


### PR DESCRIPTION
This PR adds cp jar build task invocation for PR builds to make sure downstream components don't break with the PR changes.