### PR TITLE
[APPSEC-4536][APPSEC-1226] Update bouncycastle to 2.0 in FedRAMP branch (#10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,15 +108,10 @@
         <!-- before updating bouncycastle.fips.version make sure
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK
         as of -->
-        <bouncycastle.fips.version>1.0.2.4</bouncycastle.fips.version>
-        <bouncycastle.tls-fips.version>1.0.13</bouncycastle.tls-fips.version>
-        <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
-        <!-- Bouncycastle update to version 2.0 This will have to be applied all .x branches,
-        here for FedRAMP builds -->
-        <bouncycastle.bc-fips-v2.version>2.0.0</bouncycastle.bc-fips-v2.version>
-        <bouncycastle.bcutil-fips-v2.version>2.0.3</bouncycastle.bcutil-fips-v2.version>
-        <bouncycastle.bcpkix-fips-v2.version>2.0.7</bouncycastle.bcpkix-fips-v2.version>
-        <bouncycastle.bctls-fips-v2.version>2.0.19</bouncycastle.bctls-fips-v2.version>
+        <bouncycastle.fips.version>2.0.0</bouncycastle.fips.version>
+        <bouncycastle.bcutil-fips.version>2.0.3</bouncycastle.bcutil-fips.version>
+        <bouncycastle.tls-fips.version>2.0.19</bouncycastle.tls-fips.version>
+        <bouncycastle.bcpkix-fips.version>2.0.7</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>
@@ -370,17 +365,6 @@
                 <version>${spotbugs.version}</version>
             </dependency>
 
-            <!-- All those need to be removed in 7.7.0-cp3-->
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
@@ -406,29 +390,11 @@
                 <artifactId>bcpkix-fips</artifactId>
                 <version>${bouncycastle.bcpkix-fips.version}</version>
             </dependency>
-
-            <!-- Bouncycastle 2.0 definitions
-             <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bc-fips</artifactId>
-                <version>${bouncycastle.bc-fips-v2.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcutil-fips</artifactId>
-                <version>${bouncycastle.bcutil-fips-v2.version}</version>
+                <version>${bouncycastle.bcutil-fips.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bctls-fips</artifactId>
-                <version>${bouncycastle.bctls-fips-v2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-fips</artifactId>
-                <version>${bouncycastle.bcpkix-fips-v2.version}</version>
-            </dependency>
-            -->
 
             <dependency>
                 <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
* update bc-fips versions, add bcutil-version

* remove redundant dependencymanagement sections

* remove redudnant version definitions