### PR TITLE
define version of commons-io and add it to dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <argLine></argLine>
         <avro.version>1.11.4</avro.version>
         <classgraph.version>4.8.138</classgraph.version>
+        <commons-io.version>2.16.0</commons-io.version>
         <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
         <azure-identity.version>1.13.0</azure-identity.version>
         <azure-storage.version>12.26.1</azure-storage.version>
@@ -228,6 +229,12 @@
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>
                 <version>${classgraph.version}</version>
+            </dependency>
+            <!-- Unify version of commons-io with ce-kafka, allow downstream repos to unpin -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>


### PR DESCRIPTION
Add commons-io to dependencies managed using the common repository:
- it is defined in ce-kafka
- it is used by multiple confluent repositories 