### PR TITLE
add okio-jvm to dependencyManagement to avoid regressions from ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.113.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <!-- okio version to match ce-kafka 7.8.x -->
+        <okio.version>3.7.0</okio.version>
         <protobuf.version>3.25.5</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
@@ -237,6 +239,12 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+            </dependency>
+            <!-- This is to match to okio version used in ce-flink / ce-kafka 7.8  -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio</artifactId>
+                <version>${okio.version}</version>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>


### PR DESCRIPTION
Add okio-jvm to dependencyManagement section as it is brought in as a transitive dependency of kafka-client / apiserver code introduces in ce-flink 