### PR TITLE
[APPSEC-4526]revert bouncycastle fips libraries upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,11 @@
         <!-- before updating bouncycastle.fips.version make sure
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK
         as of -->
-        <bouncycastle.fips.version>2.0.0</bouncycastle.fips.version>
+        <!-- BC should be upated to version 2.0 in Q1 2025, bcutil-fips is 2.0 only, so no change there -->
+        <bouncycastle.fips.version>1.0.2.4</bouncycastle.fips.version>
         <bouncycastle.bcutil-fips.version>2.0.3</bouncycastle.bcutil-fips.version>
-        <bouncycastle.tls-fips.version>2.0.19</bouncycastle.tls-fips.version>
-        <bouncycastle.bcpkix-fips.version>2.0.7</bouncycastle.bcpkix-fips.version>
+        <bouncycastle.tls-fips.version>1.0.19</bouncycastle.tls-fips.version>
+        <bouncycastle.bcpkix-fips.version>1.0.7</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>


### PR DESCRIPTION
The late integration tests caught issues in bouncycastle 2.0 integration with ldaps.
This is a temporary revert until q1 2025
Revert https://github.com/confluentinc/common/pull/651
Revert https://github.com/confluentinc/common/pull/646