### PR TITLE
[APPSEC-4850] update netty to 4.1.115

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.113.Final</netty.version>
+        <netty.version>4.1.115.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>3.25.5</protobuf.version>
         <!-- Update to 2.0.0 for unit test patch usage -->


### PR DESCRIPTION
Update netty to resolve false positive CVE reports (vuln only affects Windows)