### PR TITLE
Revert upgrade to Avro 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
-        <avro.version>1.12.0</avro.version>
+        <avro.version>1.11.4</avro.version>
         <classgraph.version>4.8.138</classgraph.version>
         <commons-io.version>2.16.0</commons-io.version>
         <aws-java-sdk.version>1.12.701</aws-java-sdk.version>


### PR DESCRIPTION
Avro 1.12.0 introduces a regression caused by https://github.com/apache/avro/pull/2389