### PR TITLE
CPBR-2063: adding block level status for semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,7 @@ semaphore:
   run_pint_merge: true
   pipeline_type: cp
   nano_version: true
+  status_level: block
   extra_deploy_args: "-Pjenkins"
   extra_build_args: "-Pjenkins"
   downstream_projects: ["rest-utils", "ksql", "newwave", "kafka-connect-replicator", "hub-client"]

--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,9 @@ semaphore:
   run_pint_merge: true
   pipeline_type: cp
   nano_version: true
+  pr_ci_gating:
+    enable: true
+    project_name: common
   status_level: block
   extra_deploy_args: "-Pjenkins"
   extra_build_args: "-Pjenkins"


### PR DESCRIPTION
This change will allow adding non blocking cp jar build addition to master branch. Only in master branch, if [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) fails, developers will still be able to merge their changes. For all the branches, [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) will be required to pass before merging changes in any CP development branch.
More details can be found in https://confluentinc.atlassian.net/wiki/spaces/ENV/pages/2871296194/Add+SemaphoreCI#Configuration and https://docs.semaphoreci.com/using-semaphore/projects#edit-status-checks


To reduce number of PR approvals, this PR also modifies service.yml to add cp jar build block in semaphore.yml to trigger cp jar build job on every PR build.

After merging the PR, cc-service-bot (which manages cp projects semaphore.yml) will be invoked on this repo to add [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) block in master branch