### PR TITLE
Adds a usage guide for StructuredJsonLayout log4j2 plugin

### DIFF
--- a/log4j2-extensions/README.md
+++ b/log4j2-extensions/README.md
@@ -1,0 +1,48 @@
+StructuredJsonLayout Plugin Usage Guide
+=======================================
+
+This guide provides instructions on how to use the `StructuredJsonLayout` plugin in a Log4j2 YAML configuration file.
+
+## Prerequisites
+
+Ensure you have the `log4j2-extensions` dependency included in your project. Add the following to your `pom.xml` if you are using Maven:
+
+```xml
+<dependency>
+    <groupId>io.confluent</groupId>
+    <artifactId>log4j2-extensions</artifactId>
+</dependency>
+```
+
+## Configuration
+
+Below is an example of how to configure the StructuredJsonLayout plugin in a Log4j2 YAML configuration file
+
+```yaml
+Configuration:
+  status: warn
+  appenders:
+    console:
+      name: Console
+      target: SYSTEM_OUT
+      StructuredJsonLayout:
+        Property:
+          - name: "property1"
+            value: "value1"
+          - name: "property2"
+            value: "value2"
+  loggers:
+    root:
+      level: info
+      appenderRefs:
+        - ref: Console
+```
+
+If you are using `SerializableSchemaAndValue`, then the following properties can be provided to `StructuredJsonLayout` to migrate to log4j2:-
+
+```yaml
+  StructuredJsonLayout:
+    Property:
+      - name: schemas.enable
+        value: false
+```

--- a/log4j2-extensions/README.md
+++ b/log4j2-extensions/README.md
@@ -10,7 +10,7 @@ Ensure you have the `log4j2-extensions` dependency included in your project. Add
 ```xml
 <dependency>
     <groupId>io.confluent</groupId>
-    <artifactId>log4j2-extensions</artifactId>
+    <artifactId>confluent-log4j2-extensions</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
This documentation will be helpful for migrating from log4j1 based StructurtedJsonLayout to log4j2.