### PR TITLE
[Do not merge] test downgrade of Java version to 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
         <spotbugs.version>4.7.1</spotbugs.version>
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
-        <java.version>17</java.version>
+        <java.version>11</java.version>
         <jackson.version>2.16.0</jackson.version>
         <jetty.version>12.0.16</jetty.version>
         <jose4j.version>0.9.5</jose4j.version>


### PR DESCRIPTION
Folks, 
This PR is to discuss the java version used across CP 8.0.
In https://github.com/confluentinc/common/pull/729
we have updated Java to version 17 per request from CPBR. Unfortunately, per @rayokota this is causing problems with clients expecting Java 11. 
I expect we'll need to delineate versions at some place - I am wondering what clients explicitly need Java 11 support? 
Should we set minimum version of Java to 11 in common and 17 in rest-utils? 
