### PR TITLE
Pin Jakarta versions to support Jetty 12 migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,8 @@
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
         <java.version>17</java.version>
         <jackson.version>2.16.0</jackson.version>
+        <jakarta-websocket-api.version>2.1.0</jakarta-websocket-api.version>
+        <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
         <jetty.version>12.0.16</jetty.version>
         <jose4j.version>0.9.5</jose4j.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
Pin the following to be used by downstream repos (ex: rest-utils) to support Jetty 12 migration. 
       <dependency>
            <groupId>jakarta.websocket</groupId>
            <artifactId>jakarta.websocket-api</artifactId>
            <version>2.1.0</version>
        </dependency>
        <dependency>
            <groupId>jakarta.servlet</groupId>
            <artifactId>jakarta.servlet-api</artifactId>
            <version>6.0.0</version>
        </dependency>

https://github.com/confluentinc/rest-utils/pull/552/files#r1999652526 