### PR TITLE
Add slf4j-log4j binding dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j-slf4j-impl.version>2.24.3</log4j-slf4j-impl.version>
+        <log4j2.version>2.24.3</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -505,7 +505,7 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <scope>runtime</scope>
-                <version>${log4j-slf4j-impl.version}</version>
+                <version>${log4j2.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.reload4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
+        <log4j-slf4j-impl.version>2.24.3</log4j-slf4j-impl.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.5</snappy.version>
@@ -499,6 +500,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j-reload4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <scope>runtime</scope>
+                <version>${log4j-slf4j-impl.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.reload4j</groupId>


### PR DESCRIPTION
Add `log4j-slf4j-impl` dependency to be used in downstream projects.

Ref: https://confluentinc.atlassian.net/browse/INIT-8980