### PR TITLE
udpate amazonSdkVersion to match ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <classgraph.version>4.8.138</classgraph.version>
         <commons-io.version>2.16.0</commons-io.version>
         <commons-codec.version>1.16.1</commons-codec.version>
-        <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
+        <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
         <azure-identity.version>1.15.3</azure-identity.version>
         <azure-storage.version>12.29.1</azure-storage.version>
         <required.maven.version>3.2</required.maven.version>


### PR DESCRIPTION
Update aws SDK to match ce-kafka and support downstream applications. 