### PR TITLE
Use JDK 11 for client compatibilty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1236,37 +1236,6 @@
             </reporting>
         </profile>
         <profile>
-            <!-- org.owasp:dependency-check-maven >= 4.0.0 will not work with JDK7 so it must be activated in a JDK>=1.8 profile.
-                 Developers can always pass -Ddependency.check.skip=true on the CLI to speed things up during development -->
-            <id>dependency-check</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-               </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>java-9+</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- Use release instead of source/target in Java 9 or higher -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <release>${java.version}</release>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>docker</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -838,8 +838,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
         <spotbugs.version>4.7.1</spotbugs.version>
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
-        <java.version>17</java.version>
+        <java.version>11</java.version>
         <jackson.version>2.16.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
         <spotbugs.version>4.7.1</spotbugs.version>
         <spotbugs.maven.plugin.version>4.7.1.0</spotbugs.maven.plugin.version>
         <java.version>17</java.version>
-        <client.java.version>11</client.java.version>
         <jackson.version>2.16.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
@@ -839,7 +838,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <inherited>true</inherited>
                 <configuration>
-                    <release>${client.java.version}</release>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -1234,6 +1234,37 @@
                     </plugin>
                 </plugins>
             </reporting>
+        </profile>
+        <profile>
+            <!-- org.owasp:dependency-check-maven >= 4.0.0 will not work with JDK7 so it must be activated in a JDK>=1.8 profile.
+                 Developers can always pass -Ddependency.check.skip=true on the CLI to speed things up during development -->
+            <id>dependency-check</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+              <plugins>
+               </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java-9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Use release instead of source/target in Java 9 or higher -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <release>${java.version}</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>docker</id>


### PR DESCRIPTION
We have updated Java to version 17 per request from CPBR. Unfortunately, this is causing problems with clients expecting Java 11. 
We'll explicitly set to 17 in rest-utils, ksql, and other repos that run server-side