### PR TITLE
Updating versions as per ce-kafka version upgrade in PR #21588

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
         <avro.version>1.11.4</avro.version>
-        <classgraph.version>4.8.138</classgraph.version>
+        <classgraph.version>4.8.179</classgraph.version>
         <commons-io.version>2.16.0</commons-io.version>
         <commons-codec.version>1.16.1</commons-codec.version>
         <commons-compress.version>1.26.1</commons-compress.version>
@@ -68,11 +68,11 @@
         <jackson.version>2.16.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
-        <jetty.version>12.0.16</jetty.version>
-        <jose4j.version>0.9.5</jose4j.version>
+        <jetty.version>12.0.22</jetty.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <kafka.scala.version>2.13</kafka.scala.version>
@@ -105,7 +105,7 @@
         <log4j2.version>2.24.3</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <snappy.version>1.1.10.5</snappy.version>
+        <snappy.version>1.1.10.7</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>
         <logredactor.version>1.0.13</logredactor.version>


### PR DESCRIPTION
### About
Updating versions of `classgraph`, `jetty`, `jose4j`, `jacoco` and `snappy` to match ce-kafka versions in https://github.com/confluentinc/ce-kafka/pull/21588