### PR TITLE
MMA-17043 | increase build time limit to 2 hours

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 1
+  hours: 2
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"


### PR DESCRIPTION
Currently observing timeout on common build. (eg - https://semaphore.ci.confluent.io/workflows/da6e397a-f555-43a9-9296-aea779fbb72e?pipeline_id=dbef5370-ceee-4249-a3a8-d9b480e7e6e2).

Increasing the build time limit to 2 hours instead of 1 hour. Why the tests might be timing out is being looked into.