### PR TITLE
Update jetty 12 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jackson.version>2.16.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
-        <jetty.version>12.0.16</jetty.version>
+        <jetty.version>12.0.23</jetty.version>
         <jose4j.version>0.9.5</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>


### PR DESCRIPTION
Update jetty 12 to latest patch version 12.0.23 which contains several important fix, including  https://github.com/jetty/jetty.project/pull/13145, which might help with kafka rest issue.