### PR TITLE
APPSEC-5684: Update commons validator

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
         <commons-io.version>2.16.0</commons-io.version>
         <commons-validator.version>1.10.0</commons-validator.version>
+        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <azure-identity.version>1.15.3</azure-identity.version>
         <azure-storage.version>12.29.1</azure-storage.version>
         <classgraph.version>4.8.138</classgraph.version>
@@ -246,6 +247,12 @@
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons-validator.version}</version>
+            </dependency>
+            <!-- Pin version of commons-beanutils as it is used transitively not only by commons-validator -->
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>${commons-beanutils.version}</version>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <avro.version>1.11.4</avro.version>
         <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
         <commons-io.version>2.16.0</commons-io.version>
+        <commons-validator.version>1.10.0</commons-validator.version>
         <azure-identity.version>1.15.3</azure-identity.version>
         <azure-storage.version>12.29.1</azure-storage.version>
         <classgraph.version>4.8.138</classgraph.version>
@@ -239,6 +240,12 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
+            </dependency>
+            <!-- Unify version of commons-validator with ce-kafka, allow downstream repos to unpin -->
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons-validator.version}</version>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>


### PR DESCRIPTION
Pin versions of commons-validator and commons-beanutils to address known vulnerability. 