### PR TITLE
update netty and auxilary bc-fips library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.124.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>3.25.5</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
@@ -114,7 +114,7 @@
         <bouncycastle.fips.version>2.1.0</bouncycastle.fips.version>
         <bouncycastle.bcutil-fips.version>2.0.3</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.0.19</bouncycastle.tls-fips.version>
-        <bouncycastle.bcpkix-fips.version>2.0.7</bouncycastle.bcpkix-fips.version>
+        <bouncycastle.bcpkix-fips.version>2.0.8</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>


### PR DESCRIPTION
Update Netty to resolve CVE-2025-55163 
Update bcpkix to resolve  CVE-2025-8916 
Downgrade bcfips to avoid FIPS certification issuesr