### PR TITLE
Cleanup in common 8.0.x: add httpclient5, remove zookeeper definitions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <aws-java-sdk-v2.version>2.29.39</aws-java-sdk-v2.version>
         <azure-identity.version>1.15.3</azure-identity.version>
         <azure-storage.version>12.29.1</azure-storage.version>
+        <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.0.1-0-ccs, 8.0.2-0-ccs)</kafka.version>
         <ce.kafka.version>[8.0.1-0-ce, 8.0.2-0-ce)</ce.kafka.version>
@@ -111,8 +112,6 @@
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>
         <logredactor.version>1.0.13</logredactor.version>
-        <zkclient.version>0.11</zkclient.version>
-        <zookeeper.version>3.8.4</zookeeper.version>
         <bouncycastle.jdk18.version>1.81</bouncycastle.jdk18.version>
         <!-- before updating bouncycastle.fips.version make sure
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK -->
@@ -302,13 +301,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- pin version of mina-core to override the definition from jetty
-                TODO: remove after update of jetty to version 12-->
-            <dependency>
-                <groupId>org.apache.mina</groupId>
-                <artifactId>mina-core</artifactId>
-                <version>2.2.4</version>
-            </dependency>
             <!-- snappy-java is brought in by kafka-clients and its version is specified
             in ce-kafka -->
             <dependency>
@@ -356,60 +348,16 @@
                 <artifactId>azure-storage-blob</artifactId>
                 <version>${azure-storage.version}</version>
             </dependency>
+            <!-- specify version of httpclient5 that is used in ce-kafka for compatibility in maven builds -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-handler</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-epoll</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ch.qos.logback</groupId>
-                        <artifactId>logback-classic</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.101tec</groupId>
-                <artifactId>zkclient</artifactId>
-                <version>${zkclient.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>slf4j-log4j12</artifactId>
-                        <groupId>org.slf4j</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>log4j</artifactId>
-                        <groupId>log4j</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.zookeeper</groupId>
-                        <artifactId>zookeeper</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Add dependency management for httpclient5 used in ce-kafka, 
Remove mina-core that should no longer be needed after jetty update
Remove zookeeper version and zkclient dependency management and version definitions