### PR TITLE
APPSEC-5909: update jetty due to tbd, merge failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <jackson.version>2.19.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
-        <jetty.version>12.0.23</jetty.version>
+        <jetty.version>12.0.25</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>


### PR DESCRIPTION
It appears that pint-merge has failed between 8.0.x and 8.1x for commit:
https://github.com/confluentinc/common/commit/348fe5585452c0d0f6f6cf016b1030c15fba79b0
