### PR TITLE
MINOR: Update jackson versions to match kafka versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
         <spotbugs.version>4.9.3</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.19.0</jackson.version>
+        <jackson.version>2.20.1</jackson.version>
+        <jackson.annotations.version>2.20</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.25</jetty.version>


### PR DESCRIPTION
jackson-annotations follows a different versioning scheme starting from 2.20, so I’ve added a new property, `jackson.annotations.version`, for the jackson-annotations library. This property needs to be used by downstream projects.

https://github.com/confluentinc/ce-kafka/pull/26252

We will update downstream projects after this