### PR TITLE
[CPBR-3661] Use default buildx builder to fix chained cross-platform builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1600,6 +1600,7 @@
                                   <tag>${docker.tag}</tag>
                                 </tags>
                                 <buildx>
+                                  <builderName>default</builderName>
                                   <platforms>${docker.buildx.platforms}</platforms>
                                 </buildx>
                               </build>


### PR DESCRIPTION
### Description
#### Summary

  - Sets <builderName>default</builderName> in the fabric8 Docker Maven plugin's buildx configuration to use the docker driver instead of the docker-container driver.
#### Problem

When building cross-platform (s390x) Docker images with fabric8's buildx support, the default docker-container driver runs BuildKit in an isolated container. This container cannot see images that were --loaded into the local Docker daemon
  during earlier stages of the Maven reactor build.

This breaks chained image builds where a downstream image depends on a locally-built upstream image (e.g., cp-server-connect-base → FROM cp-server → FROM cp-base-java). The build fails with: ERROR: cp-server:<tag>: not found

#### Fix

  Setting builderName=default tells fabric8 to use the docker driver, which uses the Docker daemon's built-in BuildKit. This driver shares the local image store, so chained FROM references resolve correctly.

#### Impact

  - No functional change to built images. Both drivers use the same BuildKit engine — the only difference is where it runs. Dockerfiles, base images, build args, and platform targeting are all unchanged.
  - The docker driver fully supports cross-platform builds via QEMU, and since we build one platform per job (amd64, arm64, s390x), there is no feature gap.
  - AMD and ARM builds are unaffected — they already work because their upstream images are pre-pushed to the registry. This fix is required for s390x where chained local builds are needed.