### PR TITLE
Fix kafka/ce.kafka version range format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.4.0-0-ccs, 8.4.1-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.4.0-0-ce, 8.4.1-0-ce)</ce.kafka.version>
+        <kafka.version>[8.4.0-0-0-ccs, 8.4.1-0-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.4.0-0-0-ce, 8.4.1-0-0-ce)</ce.kafka.version>
         <easymock.version>5.2.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->


### PR DESCRIPTION
## Summary
- Restore the hotfix segment in version ranges that was accidentally removed during the 8.4.0-0 bump
- ce-kafka uses the 3-segment format (e.g., `8.4.0-0-0-ce`) for compatibility with hotfix versioning introduced in 8.x

## Changes
```diff
-<kafka.version>[8.4.0-0-ccs, 8.4.1-0-ccs)</kafka.version>
-<ce.kafka.version>[8.4.0-0-ce, 8.4.1-0-ce)</ce.kafka.version>
+<kafka.version>[8.4.0-0-0-ccs, 8.4.1-0-0-ccs)</kafka.version>
+<ce.kafka.version>[8.4.0-0-0-ce, 8.4.1-0-0-ce)</ce.kafka.version>
```

## Root cause fix
The depot release-tools automation has been fixed to preserve this format going forward: https://github.com/confluentinc/depot/pull/695

## Test plan
- [ ] Verify downstream builds resolve ce-kafka dependencies correctly

🤖 Generated with [Claude Code](https://claude.ai/code)