### PR TITLE
[BOM] Bump commons-validator, junit-bom, bouncycastle FIPS on 8.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <commons-io.version>2.20.0</commons-io.version>
         <commons-codec.version>1.16.1</commons-codec.version>
         <commons-compress.version>1.28.0</commons-compress.version>
-        <commons-validator.version>1.10.0</commons-validator.version>
+        <commons-validator.version>1.10.1</commons-validator.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -80,7 +80,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
+        <junit.jupiter.version>5.13.1</junit.jupiter.version>
         <kafka.scala.version>2.13</kafka.scala.version>
         <scala.version>2.13.11</scala.version>
         <maven-assembly.version>3.3.0</maven-assembly.version>
@@ -121,9 +121,9 @@
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK -->
         <!-- BC should be upated to version 2.0 in Q1 2025, bcutil-fips is 2.0 only, so no change there -->
         <bouncycastle.fips.version>2.1.2</bouncycastle.fips.version>
-        <bouncycastle.bcutil-fips.version>2.1.4</bouncycastle.bcutil-fips.version>
-        <bouncycastle.tls-fips.version>2.1.20</bouncycastle.tls-fips.version>
-        <bouncycastle.bcpkix-fips.version>2.1.9</bouncycastle.bcpkix-fips.version>
+        <bouncycastle.bcutil-fips.version>2.1.5</bouncycastle.bcutil-fips.version>
+        <bouncycastle.tls-fips.version>2.1.22</bouncycastle.tls-fips.version>
+        <bouncycastle.bcpkix-fips.version>2.1.10</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.20.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>


### PR DESCRIPTION
## Summary
These dependencies in common-parent are older than ce-kafka. All are minor or patch version bumps.

- Bump `commons-validator` 1.10.0 → 1.10.1 (patch)
- Bump `junit-bom` (junit.jupiter.version) 5.8.2 → 5.13.1 (minor)
- Bump `bcutil-fips` 2.1.4 → 2.1.5 (patch)
- Bump `bctls-fips` 2.1.20 → 2.1.22 (patch)
- Bump `bcpkix-fips` 2.1.9 → 2.1.10 (patch)
- 
**Not included in this PR (major version bumps, leaving as-is for now):**

- `hamcrest-all` 1.3 → `hamcrest` 3.0 — artifact renamed in 2.x, 2 major versions behind
- `jolokia-jvm` 1.7.1 → `jolokia-agent-jvm` 2.0.3 — artifact renamed in 2.x, 1 major version behind

These are major version bumps with artifact renames that affect ~30 downstream repos (hamcrest) and several Docker image repos (jolokia). Keeping them unchanged in common-parent until we can coordinate the migration.
