### PR TITLE
[BOM] Bump hamcrest 1.3 → 3.0, jolokia 1.7.1 → 2.0.3 on 8.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.132.Final</netty.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>3.0</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
         <protobuf.version>4.32.1</protobuf.version>
@@ -125,7 +125,7 @@
         <bouncycastle.tls-fips.version>2.1.20</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.9</bouncycastle.bcpkix-fips.version>
         <jmx_prometheus_javaagent.version>0.20.0</jmx_prometheus_javaagent.version>
-        <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
+        <jolokia-jvm.version>2.0.3</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -608,7 +608,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
## Summary
Major version bumps -- these dependencies in common-parent are older than ce-kafka.

- Bump `hamcrest-all` 1.3 → `hamcrest` 3.0 (artifact renamed in 2.x, major version bump)
- Bump `jolokia-jvm` 1.7.1 → 2.0.3 (major version bump, property only — no dependency block in this POM)

⚠️ These are major version bumps that may break downstream repos. Opening as draft to see CI results.

## Test plan
- [ ] CI passes on 8.0.x
- [ ] Check downstream repos that use `hamcrest-all` or `jolokia-jvm.version`
- [ ] Verify merge-up compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)