### PR TITLE
[BOM] Bump jackson-bom from 2.16.0 to 2.21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.34</jetty.version>


### PR DESCRIPTION
## Summary
- Bump `jackson-bom` from 2.16.0 to 2.21.2 to align with ce-kafka master
- Prerequisite for confluent-common-bom adoption (DP-18572)
- Ref: https://github.com/confluentinc/ce-kafka/commit/79c12c0d83d3a72a72d2a9f32ef9f8816dcbfe46
