### PR TITLE
CPBR-3611: Upgrade jmx_prometheus_javaagent from 0.18.0 to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <bouncycastle.bcutil-fips.version>2.1.4</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.1.20</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.9</bouncycastle.bcpkix-fips.version>
-        <jmx_prometheus_javaagent.version>0.18.0</jmx_prometheus_javaagent.version>
+        <jmx_prometheus_javaagent.version>1.0.1</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>


### PR DESCRIPTION
## Summary
- Upgrade `jmx_prometheus_javaagent` from `0.18.0` to `1.0.1` to remediate CVE/security vulnerability
- This is a major version bump (0.x → 1.x) — the 1.0.x release includes security fixes, performance improvements, and updated dependencies
- Version `0.18.0` is flagged as vulnerable per CPBR-3611 / CFK-4241

## Jira
- [CPBR-3611](https://confluentinc.atlassian.net/browse/CPBR-3611)
- [CFK-4241](https://confluentinc.atlassian.net/browse/CFK-4241)



[CPBR-3611]: https://confluentinc.atlassian.net/browse/CPBR-3611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFK-4241]: https://confluentinc.atlassian.net/browse/CFK-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ