### PR TITLE
[BOM] Cherry-pick #938: Bump commons-io, commons-compress, easymock, spotbugs on 8.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <classgraph.version>4.8.179</classgraph.version>
-        <commons-io.version>2.16.0</commons-io.version>
+        <commons-io.version>2.20.0</commons-io.version>
         <commons-codec.version>1.16.1</commons-codec.version>
-        <commons-compress.version>1.26.1</commons-compress.version>
+        <commons-compress.version>1.28.0</commons-compress.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -63,12 +63,12 @@
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.2.1-0-0-ccs, 8.2.2-0-0-ccs)</kafka.version>
         <ce.kafka.version>[8.2.1-0-0-ce, 8.2.2-0-0-ce)</ce.kafka.version>
-        <easymock.version>5.2.0</easymock.version>
+        <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-        <spotbugs.version>4.9.3</spotbugs.version>
-        <spotbugs.maven.plugin.version>4.9.3.0</spotbugs.maven.plugin.version>
+        <spotbugs.version>4.9.8</spotbugs.version>
+        <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.19.0</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>


### PR DESCRIPTION
## Summary
- Cherry-pick dependency bumps from PR #938 (8.0.x) that failed to merge up
- commons-io: 2.16.0 → 2.20.0
- commons-compress: 1.26.1 → 1.28.0
- easymock: 5.2.0 → 5.6.0
- spotbugs: 4.9.3 → 4.9.8
- spotbugs-maven-plugin: 4.9.3.0 → 4.9.8.0

## Context
These bumps were merged to 8.0.x via PRs #935 and #938 but failed to merge up due to pint merge conflicts (kafka.version proximity issue). See also #957 (8.1.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)