### PR TITLE
[BOM] Bump jackson-bom to 2.21.2 and add jackson.annotations.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.34</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.21.2</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.34</jetty.version>


### PR DESCRIPTION
## Summary
- Bump jackson-bom from 2.16.0 to 2.21.2
- Add `jackson.annotations.version` property (2.21) matching the pattern from #885

Some downstream project need to be updated to use jackson.annotation after this. 
https://github.com/confluentinc/rest-utils/pull/678
https://github.com/confluentinc/hub-client/pull/171

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)