### PR TITLE
[BOM] Bump jacoco-maven-plugin from 0.8.7 to 0.8.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <grpc.version>1.75.0</grpc.version>
         <gson.version>2.9.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.8.2</junit.jupiter.version>
         <kafka.scala.version>2.13</kafka.scala.version>


### PR DESCRIPTION
## Summary
- Bump jacoco-maven-plugin from 0.8.7 to 0.8.13 to align 8.0.x with all other branches
- Backport of https://github.com/confluentinc/common/pull/791 (merged on master)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)