### PR TITLE
Bump easymock to 5.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.1.3-0-ccs, 8.1.4-0-ccs)</kafka.version>
         <ce.kafka.version>[8.1.3-0-ce, 8.1.4-0-ce)</ce.kafka.version>
-        <easymock.version>5.2.0</easymock.version>
+        <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>


### PR DESCRIPTION
## Summary
- Pint merge failed back then and didn't merge up the changes in 8.0.x. Bump easymock from 5.2.0 to 5.6.0 to align with 8.0.x
- Pint will merge this up to 8.2.x, 8.3.x, and master

## Test plan
- [ ] CI passes on 8.1.x
- [ ] Pint merges up to 8.2.x, 8.3.x, and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)