### PR TITLE
Bump protobuf to 4.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
-        <protobuf.version>4.32.1</protobuf.version>
+        <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
## Summary
- Bump protobuf from 4.32.1 to 4.34.0 to align with 8.3.x and master
- Pint will merge this up to 8.1.x, 8.2.x, 8.3.x, and master

## Test plan
- [ ] CI passes on 8.0.x
- [ ] Pint merges up to 8.1.x, 8.2.x, 8.3.x, and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)