### PR TITLE
Bump snappy-java to 1.1.10.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <logback-core.version>1.5.27</logback-core.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <snappy.version>1.1.10.7</snappy.version>
+        <snappy.version>1.1.10.8</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>
         <logredactor.version>1.0.17</logredactor.version>


### PR DESCRIPTION
## Summary
- Bump snappy-java from 1.1.10.7 to 1.1.10.8 to align with 8.3.x and master
- Pint will merge this up to 8.1.x, 8.2.x, 8.3.x, and master

## Test plan
- [ ] CI passes on 8.0.x
- [ ] Pint merges up to 8.1.x, 8.2.x, 8.3.x, and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)