### PR TITLE
Bump bouncycastle.jdk18 to 1.84 [security]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>
         <logredactor.version>1.0.17</logredactor.version>
-        <bouncycastle.jdk18.version>1.82</bouncycastle.jdk18.version>
+        <bouncycastle.jdk18.version>1.84</bouncycastle.jdk18.version>
         <!-- before updating bouncycastle.fips.version make sure
         that the library version you're updating to is FIPS certified e.g. 1.0.2.4 -> 1.0.2.5 is not OK -->
         <!-- BC should be upated to version 2.0 in Q1 2025, bcutil-fips is 2.0 only, so no change there -->


### PR DESCRIPTION
## Summary
- Bump bouncycastle.jdk18 from 1.82 to 1.84 (security fix) to align with master
- Pint will merge this up to 8.1.x, 8.2.x, 8.3.x, and master

## Test plan
- [ ] CI passes on 8.0.x
- [ ] Pint merges up to 8.1.x, 8.2.x, 8.3.x, and master

🤖 Generated with [Claude Code](https://claude.com/claude-code)