### PR TITLE
update log4j to 2.25.4 (FedRAMP) 

### DIFF
--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j2.version>2.25.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <logback-core.version>1.5.27</logback-core.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
Update log4j to remediate known vulnerabilities. 