### PR TITLE
fix: increase CI execution time limit to 90 minutes

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,7 +16,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 1
+  minutes: 90
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.x'"

--- a/service.yml
+++ b/service.yml
@@ -5,6 +5,8 @@ codeowners:
   enable: true
 semaphore:
   enable: true
+  execution_time_limit:
+    minutes: 90
   run_pint_merge: true
   pipeline_type: cp
   nano_version: true


### PR DESCRIPTION
## Summary
- Increase Semaphore `execution_time_limit` from 60 to 90 minutes
- The "Trigger and wait for CP Jar Build Task" job times out when downstream builds take longer than 60 minutes

## Evidence
- [Timed out job](https://semaphore.ci.confluent.io/jobs/6602b263-fe40-4a6a-bf5e-e89d3fe05c8c) — stopped after 59 minutes while cp-jar-build was still running
- [Triggered pipeline](https://semaphore.ci.confluent.io/workflows/36f59975-09c8-434d-94a8-691bda33ba8d) — actually passed, but the trigger job had already timed out

## Test plan
- [ ] Verify CI pipeline completes within 90 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)