### PR TITLE
feat: import confluent-common-bom for dependency version management (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,117 +231,24 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- our deps-->
+            <!-- Confluent Common BOM - manages third-party dependency versions -->
             <dependency>
-              <groupId>org.apache.avro</groupId>
-              <artifactId>avro</artifactId>
-              <version>${avro.version}</version>
-            </dependency>
-            <!-- Pin the classgraph version to match version used in ce-kafka.
-            The outadated version is brought by schema-registry transitive
-            dependency mbknor-jackson -->
-            <dependency>
-                <groupId>io.github.classgraph</groupId>
-                <artifactId>classgraph</artifactId>
-                <version>${classgraph.version}</version>
-            </dependency>
-            <!-- Unify version of commons-io with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-            <!-- Unify version of commons-lang3 with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
-            </dependency>
-            <!-- Pin version of commons-beanutils as it is used transitively not only by commons-validator -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>${commons-codec.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>${commons-compress.version}</version>
-            </dependency>
-            <!-- Unify version of commons-validator with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>commons-validator</groupId>
-                <artifactId>commons-validator</artifactId>
-                <version>${commons-validator.version}</version>
-            </dependency>
-            <!-- Unify version of grpc-version with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-bom</artifactId>
-                <version>1.75.0</version>
+                <groupId>io.confluent</groupId>
+                <artifactId>confluent-common-bom</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- This is to match to okio version used in ce-flink / ce-kafka 7.8  -->
+
+            <!-- Jackson BOM - not yet in confluent-common-bom -->
             <dependency>
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio-jvm</artifactId>
-                <version>${okio.version}</version>
+              <groupId>com.fasterxml.jackson</groupId>
+              <artifactId>jackson-bom</artifactId>
+              <version>${jackson.version}</version>
+              <scope>import</scope>
+              <type>pom</type>
             </dependency>
-            <!-- This is to unify the version of Protocol Buffers across CP -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <!-- snakeyaml is brought in by several confluent libraries
-                 as "provided" dependency, thus leading to usage of
-                 outdated versions. This instructs projects using this pom
-                 to use this snakeyaml version, unless otherwise overriden.
-                 After this change, we should remove all the snakeyaml re-definitions
-                 in other Confluent repositories. -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
-            </dependency>
-            <!-- Unify jetty across CP, remove jetty definition from
-            rest-utils after this goes through -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>${jetty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- snappy-java is brought in by kafka-clients and its version is specified
-            in ce-kafka -->
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.version}</version>
-            </dependency>
-            <!-- jose4j is used in ce-kafka and its version is specified
-            in ce-kafka, this is for maven projects to use the correct version -->
-            <dependency>
-                <groupId>org.bitbucket.b_c</groupId>
-                <artifactId>jose4j</artifactId>
-                <version>${jose4j.version}</version>
-            </dependency>
-            <!-- we define guava version above, its version is specified
-            in ce-kafka, this is for maven projects to use the correct version -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-            <!-- we define aws-java-sdk azure-identity and azure-storage-blob
-            versions, to match the versions in ce-kafka -->
+            <!-- AWS SDKs - not in confluent-common-bom -->
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
@@ -356,6 +263,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Azure - not in confluent-common-bom (BOM uses azure-sdk-bom instead) -->
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
@@ -371,73 +279,16 @@
                 <artifactId>azure-security-keyvault-keys</artifactId>
                 <version>${azure-security-keyvault-keys.version}</version>
             </dependency>
-            <!-- specify version of httpclient5 that is used in ce-kafka for compatibility in maven builds -->
+
+            <!-- log4j-slf4j-impl: keep for runtime scope (BOM does not set scope) -->
             <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${httpclient5.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <version>${spotbugs.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.jdk18.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.jdk18.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bc-fips</artifactId>
-                <version>${bouncycastle.fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bctls-fips</artifactId>
-                <version>${bouncycastle.tls-fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-fips</artifactId>
-                <version>${bouncycastle.bcpkix-fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-fips</artifactId>
-                <version>${bouncycastle.bcutil-fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <scope>runtime</scope>
+                <version>${log4j2.version}</version>
             </dependency>
 
-            <!-- Jackson artifacts with individual versioning -->
-            <dependency>
-              <groupId>com.fasterxml.jackson</groupId>
-              <artifactId>jackson-bom</artifactId>
-              <version>${jackson.version}</version>
-              <scope>import</scope>
-              <type>pom</type>
-            </dependency>
-            <!-- We fix the scala version to prevent downstream projects from bringing in
-            different minor versions of Scala via different dependencies -->
+            <!-- Scala - not in confluent-common-bom -->
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
@@ -496,42 +347,7 @@
                 <artifactId>connect-file</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-reload4j</artifactId>
-                <version>${slf4j-reload4j.version}</version>
-            </dependency>
-            <!-- add version definition of logback that is
-            a transitive dependency of ce-kafka -> resource manager
-            This is needed as maven brings back dependency excluded in bazel -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-slf4j-impl</artifactId>
-                <scope>runtime</scope>
-                <version>${log4j2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.reload4j</groupId>
-                <artifactId>reload4j</artifactId>
-                <version>${reload4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.confluent</groupId>
-                <artifactId>logredactor</artifactId>
-                <version>${logredactor.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
+
             <!--this is our own artifacts, but lets others inherit-->
             <dependency>
                 <groupId>io.confluent</groupId>
@@ -551,47 +367,11 @@
 
             <!--test deps-->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.easymock</groupId>
-                <artifactId>easymock</artifactId>
-                <version>${easymock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-core</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-easymock</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,13 @@
             <id>confluent</id>
             <url>https://packages.confluent.io/maven/</url>
         </repository>
+        <repository>
+            <id>confluent-common-bom-snapshots</id>
+            <url>https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -220,13 +220,6 @@
             <id>confluent</id>
             <url>https://packages.confluent.io/maven/</url>
         </repository>
-        <repository>
-            <id>confluent-common-bom-snapshots</id>
-            <url>https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
## Summary
- Backport of #977 to 8.0.x
- Import `confluent-common-bom` to manage third-party dependency versions, replacing inline `dependencyManagement` entries in `common-parent`
- Dependencies now managed by the BOM: avro, classgraph, commons-*, grpc, protobuf, snakeyaml, jetty, snappy, jose4j, guava, httpclient5, slf4j, jaxb, spotbugs, bouncycastle, gson, netty, logback, reload4j, logredactor, junit, easymock, powermock

## Test plan
- [ ] CI passes (Test block)
- [ ] CP Jar Build CI Gating passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)