### PR TITLE
MINOR: Add kafka-clients test-fixtures dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -640,6 +640,19 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+                <classifier>test-fixtures</classifier>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
TestSslUtils and TestUtils were moved from the kafka-clients test classifier to a new test-fixtures classifier in Kafka 8.4.0-113-ccs. Add a managed entry for the test-fixtures classifier so downstream projects can depend on it without specifying the version explicitly.