### PR TITLE
Update Jetty to 12.0.35 and Netty to 4.1.133 in FR branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <jackson.version>2.18.6</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
-        <jetty.version>12.0.34</jetty.version>
+        <jetty.version>12.0.35</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <grpc.version>1.75.0</grpc.version>
         <gson.version>2.9.0</gson.version>
@@ -99,7 +99,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->


### PR DESCRIPTION
Update Jetty to 12.0.35 and Netty to 4.1.133 in CP FedRAMP branch.