### PR TITLE
Fix the scope of jetty-bom import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
                 <version>${jetty.version}</version>
+                <scope>import</scope>
             </dependency>
             <!-- snappy-java is brought in by kafka-clients and its version is specified
             in ce-kafka -->


### PR DESCRIPTION
Fix the scope of jetty bom - this is a fix for #990 that should have been applied to 7.5.x through 7.9.x only