### PR TITLE
cap ce/ccs kafka version ranges below 8.3.0-1416 (unblock polluted artifacts)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.3.0-0-ccs, 8.3.1-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.3.0-0-ce, 8.3.1-0-ce)</ce.kafka.version>
+        <kafka.version>[8.3.0-0-ccs, 8.3.0-1416-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.3.0-0-ce, 8.3.0-1416-0-ce)</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->


### PR DESCRIPTION
## Summary

- Caps `ce.kafka.version` and `kafka.version` ranges at `8.3.0-1416-0-*` to exclude polluted artifacts from the resolver
- Immediate unblock for downstream builds that were resolving `ce.kafka.version` to `8.3.0-1416-0-ce` instead of the correct hotfix on `8.3.x` (e.g. `8.3.0-1415-7-ce`)

## Why

`v8.3.0-1416-0-ce` and `v8.3.0-1417-0-ce` were published to CodeArtifact on May 15 and May 18 from re-runs of the ce-kafka master pipeline at the old commit [`b94d8c80a1a`](https://github.com/confluentinc/ce-kafka/commit/b94d8c80a1a) (Mar 31). At that commit `.bazelrc.release-version` still read `8.3.0-0-0-ce` — master was bumped to `8.4.0` only on Apr 15. Each pipeline run:

1. Read `current_version = 8.3.0` from the stale checkout
2. Did not pass `--hotfix-patch` (branch reported was `master`, not `8.3.x`), so the reachability filter in `ci_tools/version/update.py:341` was skipped
3. Global-searched `v8.3.0-*` tags, picked the highest, bumped nano → `8.3.0-1416-0-ce`
4. Published the artifact to CodeArtifact

The `resolver-maven-plugin` then correctly picked the highest matching version in `[8.3.0-0-ce, 8.3.1-0-ce)` — which was the polluted `1416-0-ce`.

## What this PR does

```diff
-<kafka.version>[8.3.0-0-ccs, 8.3.1-0-ccs)</kafka.version>
-<ce.kafka.version>[8.3.0-0-ce, 8.3.1-0-ce)</ce.kafka.version>
+<kafka.version>[8.3.0-0-ccs, 8.3.0-1416-0-ccs)</kafka.version>
+<ce.kafka.version>[8.3.0-0-ce, 8.3.0-1416-0-ce)</ce.kafka.version>
```

After this change the resolver will pick the highest `1415-x` available (currently `1415-9-ce`).

## Follow-ups (not in this PR)

- Yank `8.3.0-1416-0-ce` and `8.3.0-1417-0-ce` from CodeArtifact
- Investigate what re-triggers the ce-kafka master pipeline at `b94d8c80a1a` (three CC release tags converge on that commit — `v2.1592.0-8.3.0-0-0-ce`, `v2.2118.0-8.3.0-0-0-ce`, `v2.2137.0-8.3.0-0-0-ce`)
- Defense in depth in ce-kafka:
  - `scripts/set_env_vars.sh`: set `RELEASE_JOB=true` (skip bump/publish) when the checked-out commit's declared version diverges from the branch's current version
  - `python/ci_tools/version/update.py:341`: always run the reachability filter, not only when `--hotfix-patch` is passed

## Test plan

- [ ] CI green
- [ ] Verify a downstream `common` consumer resolves `ce.kafka.version` to `1415-9-ce` (or whatever the latest pre-1416 is in CodeArtifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
