### PR TITLE
Add jetty-alpn-*-client artifacts to dependencyManagement (7.8.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,22 @@
             <!-- Jetty core artifacts -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-conscrypt-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-alpn-conscrypt-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-client</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- PR #990 (\`9c2d2eaa22\`) replaced \`jetty-bom\` in \`dependencyManagement\` with explicit per-artifact entries, but only included the three \`*-server\` variants. The mirror \`*-client\` variants — previously transitively managed by \`jetty-bom\` — were missed.
- This broke any downstream consumer that depended on these artifacts without a version. Concretely, the cp_packaging *Build rest-utils jar* job started failing on \`rest-utils/7.8.x\` (https://semaphore.ci.confluent.io/jobs/87a001a4-c757-4d91-b379-4a0f9de9c9d2):

  > \`'dependencies.dependency.version' for org.eclipse.jetty:jetty-alpn-java-client:jar is missing. @ rest-utils/fips-tests/pom.xml line 50, column 21\`

- rest-utils worked around this with confluentinc/rest-utils#704 (7.8.x) and confluentinc/rest-utils#705 (7.9.x) by declaring \`<version>\${jetty.version}</version>\` explicitly, but the proper fix lives here: restore the \`*-client\` triple to \`dependencyManagement\` so all downstream consumers (current and future) get the right version without each having to declare it themselves.

Adds, mirroring the \`*-server\` set already in place:
- \`jetty-alpn-client\`
- \`jetty-alpn-conscrypt-client\`
- \`jetty-alpn-java-client\`

All resolve to \`\${jetty.version}\`, identical to what \`jetty-bom\` provided before.

## Test plan
- [ ] Re-run rest-utils 7.8.x cp_packaging *Build rest-utils jar* with this version of common and confirm it passes
- [ ] Confirm no Maven errors about missing versions for any of the three new artifacts
- [ ] Spot-check that resolved versions for jetty-alpn-*-client match \`\${jetty.version}\` (9.4.61)

## Related
- 7.9.x companion: filed alongside this PR
- rest-utils workarounds: confluentinc/rest-utils#704, confluentinc/rest-utils#705

🤖 Generated with [Claude Code](https://claude.com/claude-code)