### PR TITLE
Add jetty-alpn-*-client artifacts to dependencyManagement (7.9.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,22 @@
             <!-- Jetty core artifacts -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-conscrypt-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-alpn-conscrypt-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-client</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary
- Mirrors confluentinc/common#1007 (7.8.x). PR #990 (\`9c2d2eaa22\`) replaced \`jetty-bom\` in \`dependencyManagement\` with explicit per-artifact entries, but only included the three \`*-server\` variants. The regression landed on \`common/7.8.x\` via \`8bc8dba5f1\` on 2026-05-14 and propagated to \`common/7.9.x\` via the recent 7.8.x→7.9.x merge (\`a9c100ddbc\`). The mirror \`*-client\` variants, previously transitively managed by \`jetty-bom\`, were missed.
- This broke any downstream consumer that depended on these artifacts without a version. Concretely, the cp_packaging *Build rest-utils jar* job started failing on \`rest-utils/7.9.x\` (https://semaphore.ci.confluent.io/jobs/a764a728-b344-4d00-95e1-d19ba46b9e3d):

  > \`'dependencies.dependency.version' for org.eclipse.jetty:jetty-alpn-java-client:jar is missing. @ rest-utils/fips-tests/pom.xml line 50, column 21\`

- rest-utils worked around this with confluentinc/rest-utils#705 (7.9.x) by declaring \`<version>\${jetty.version}</version>\` explicitly, but the proper fix lives here: restore the \`*-client\` triple to \`dependencyManagement\` so all downstream consumers (current and future) get the right version without each having to declare it themselves.

Adds, mirroring the \`*-server\` set already in place:
- \`jetty-alpn-client\`
- \`jetty-alpn-conscrypt-client\`
- \`jetty-alpn-java-client\`

All resolve to \`\${jetty.version}\`, identical to what \`jetty-bom\` provided before.

## Test plan
- [ ] Re-run rest-utils 7.9.x cp_packaging *Build rest-utils jar* with this version of common and confirm it passes
- [ ] Confirm no Maven errors about missing versions for any of the three new artifacts
- [ ] Spot-check that resolved versions for jetty-alpn-*-client match \`\${jetty.version}\` (9.4.61)

## Related
- 7.8.x companion: confluentinc/common#1007
- rest-utils workarounds: confluentinc/rest-utils#704, confluentinc/rest-utils#705

🤖 Generated with [Claude Code](https://claude.com/claude-code)