### PR TITLE
Remove newwave from downstream trigger list (no 8.1.x branch exists)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -113,7 +113,6 @@ after_pipeline:
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
               sem-trigger -p rest-utils -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p newwave -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-connect-replicator -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p hub-client -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi


### PR DESCRIPTION
## Why
- `sem-trigger -p newwave` 404s on every 8.1.x build — `confluentinc/newwave` has no 8.1.x branch (latest newwave branch is 8.0.x).

## Change
- Drop the `sem-trigger -p newwave` line from the `after_pipeline` block in `.semaphore/semaphore.yml`.

