### PR TITLE
Bump log4j2 to 2.25.4 for CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j2.version>2.24.3</log4j2.version>
+        <log4j2.version>2.25.4</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.5</snappy.version>


### PR DESCRIPTION
## Summary
- Bump log4j2 from 2.24.3 to 2.25.4 
- Updating at common level so all downstream repos (rest-utils, kafka-rest, ce-kafka-rest, ksqldb) inherit the fix

