### PR TITLE
CP 8.1.x build fixes: re-add jackson-annotations, remove new-wave from the downstream test builds

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,8 +58,8 @@ blocks:
           commands:
             - ci-tools ci-update-version --direct-pom-edit
             - ci-tools ci-push-tag
-            - mvn -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode 
-              -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/ 
+            - mvn -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode
+              -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
   - name: CP Jar Build CI Gating
     dependencies: []
@@ -113,7 +113,6 @@ after_pipeline:
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
               sem-trigger -p rest-utils -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p newwave -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-connect-replicator -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p hub-client -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.21.2</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.35</jetty.version>


### PR DESCRIPTION
Additional fixes in common 8.1.x to unblock the releases
- re-add jacksonAnnotations.version as some downstream projects still rely on it
- remove newwave as downstream build see #1013 