### PR TITLE
Set protobuf.version to 4.32.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
-        <protobuf.version>4.34.0</protobuf.version>
+        <protobuf.version>4.32.1</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
Cherry-pick of #1017 to the `8.1.4` branch. Sets `<protobuf.version>` to `4.32.1` in the root `pom.xml` (previously `4.34.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)