### PR TITLE
Revert protobuf.version to 4.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
-        <protobuf.version>4.32.1</protobuf.version>
+        <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>


### PR DESCRIPTION
To unblock SR, reverts `<protobuf.version>` back to `4.34.0` in the root `pom.xml` on the `8.0.x` branch (currently `4.32.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)