### PR TITLE
CPBR-3642: Scope findbugs:annotations as Provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,15 @@
                 <version>${spotbugs.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- CPBR-3642: LGPL-2.1 findbugs annotations are compile-time only and pulled
+                 transitively (jackson-datatype-protobuf). Force provided so they are not
+                 bundled into shipped packages. -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+                <version>3.0.1</version>
+                <scope>provided</scope>
+            </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>


### PR DESCRIPTION
### Description
This PR adds a dependency management  entry in the common parent POM to force `com.google.code.findbugs:annotations` (the LGPL-2.1 `annotations-3.0.1.jar`) to `provided` scope.

This jar is **not** declared in any CP repo, it is pulled transitively via `com.hubspot.jackson:jackson-datatype-protobuf` (compile scope, version pinned by `com.hubspot:basepom`) and was being bundled into shipped packages under across many components (ksqldb, confluent-control-center, confluent-security/*, etc.). It carries only compile-time annotations, so it has zero runtime impact. Scoping it `provided` here removes it from the runtime classpath in a single change.

To be pint merged upto master.