### PR TITLE
Bump gson.version to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <jetty.version>12.0.36</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <grpc.version>1.75.0</grpc.version>
-        <gson.version>2.9.0</gson.version>
+        <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
## What

During confluent-common-bom integration, we intentionally keep the dependency properties section since it is currently used by some downsteam repos. Before we clean the downstream up, we keep those for now. 

Bump `gson.version` property from `2.9.0` → `2.11.0` in `common-parent` on the `8.0.x` line.

## Why

`confluent-common-bom` (0.1.1) manages gson at `2.11.0`. Aligning `common-parent` property on `8.0.x` to match.

## Risk

cp repos inherit common as parent will use new gson version

gson 2.9.0 → 2.11.0 is a backward-compatible minor upgrade (additive APIs + bug/security fixes, no API removals). Low risk for consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)