### PR TITLE
Update netty to 4.1.135

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>3.25.5</protobuf.version>
         <powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
Update netty to 4.1.135 to resolve known issues.

Emergency patch release fix for Netty CVEs:
APPSEC-7210, APPSEC-7211, APPSEC-7212, APPSEC-7213, APPSEC-7214, APPSEC-7215, APPSEC-7216

Applies the same one-line netty bump as PR #1025 (already merged across all
.x branches) to the 7.5.16 release branch for the emergency patch.