### PR TITLE
Update netty to 4.1.135

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>


### PR DESCRIPTION
Update netty to 4.1.135 to resolve known issues.

Emergency patch release fix for Netty CVEs:
APPSEC-7210, APPSEC-7211, APPSEC-7212, APPSEC-7213, APPSEC-7214, APPSEC-7215, APPSEC-7216

Applies the same one-line netty bump as PR #1025 (already merged across all
.x branches) to the 8.1.5 release branch for the emergency patch.