### PR TITLE
chore: bump confluent-common-bom to 0.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <commons-codec.version>1.16.1</commons-codec.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <commons-validator.version>1.10.1</commons-validator.version>
-        <confluent-common-bom.version>0.1.1</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.2</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <log4j2.version>2.25.4</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <logback-core.version>1.5.33</logback-core.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <snakeyaml.version>2.6</snakeyaml.version>
         <snappy.version>1.1.10.8</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>


### PR DESCRIPTION
## Summary
- Bumps `confluent-common-bom.version` from `0.1.1` to `0.1.2`.
- Picks up the `snakeyaml` 2.0 -> 2.6 bump managed by the BOM (the only actual dependency-version change between those two BOM releases; the rest were CI tooling additions in `confluent-common-bom`, not dependency changes).
- Downstream repos might use `snakeyaml` properties. We need to keep this align with confluent-common-bom version before we migrate downstream repos. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)