### PR TITLE
Remove properties for deps fully managed by confluent-common-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,7 @@
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
-        <classgraph.version>4.8.179</classgraph.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <commons-codec.version>1.16.1</commons-codec.version>
-        <commons-compress.version>1.28.0</commons-compress.version>
-        <commons-validator.version>1.10.1</commons-validator.version>
         <confluent-common-bom.version>0.1.2</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
@@ -75,8 +71,6 @@
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.36</jetty.version>
-        <jose4j.version>0.9.6</jose4j.version>
-        <grpc.version>1.75.0</grpc.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
@@ -102,8 +96,6 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.135.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <!-- okio version to match ce-kafka 7.8.x -->
-        <okio.version>3.7.0</okio.version>
         <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
@@ -112,7 +104,6 @@
         <log4j2.version>2.25.4</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <logback-core.version>1.5.27</logback-core.version>
-        <snakeyaml.version>2.6</snakeyaml.version>
         <snappy.version>1.1.10.8</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>


### PR DESCRIPTION
## Summary
- Removes 8 `<properties>` entries (`classgraph.version`, `commons-codec.version`, `commons-compress.version`, `commons-validator.version`, `grpc.version`, `jose4j.version`, `okio.version`, `snakeyaml.version`) that existed only for downstream backward-compat.
- Per the [DP-18877](https://confluentinc.atlassian.net/browse/DP-18877) downstream-usage audit, none of these have a live inheritor: repos that use these artifacts already override the version locally, and each value exactly matches what `confluent-common-bom` (already imported here) manages — so removal is a no-op for every consumer.
- `gson.version` is intentionally **not** touched in this PR — `schema-registry` still inherits it directly and it has drifted from the BOM's version (2.9.0 vs 2.11.0), so it needs downstream migration first (tracked via https://github.com/confluentinc/schema-registry/pull/4423).

## Test plan
- [ ] CI build passes
- [ ] Confirm no downstream repo in the common-parent inheritance chain still references any of the removed properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DP-18877]: https://confluentinc.atlassian.net/browse/DP-18877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ