### PR TITLE
[URGENT] Restore jose4j.version property (regression from #1044)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.36</jetty.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>


### PR DESCRIPTION
## Summary
- **Regression:** PR #1044 removed `jose4j.version` from `common`'s properties, assuming nothing referenced the inherited value directly. That assumption was wrong.
- `confluent-security-plugins-common`'s `pom.xml` declares an explicit `<dependency>` on `org.bitbucket.b_c:jose4j` versioned via `${jose4j.version}` inherited from `common-parent`. Without the property, Maven fails at **POM-parsing time**:
  ```
  'dependencies.dependency.version' for org.bitbucket.b_c:jose4j:jar must be a valid version but is '${jose4j.version}'
  ```
- Confirmed via CP Jar Build CI Gating on [PR #1045](https://github.com/confluentinc/common/pull/1045) — `Build security jar` fails with this exact error. Since #1044 is already merged into `8.0.x`, this is a **live regression**, not just a risk.
- This restores only the property (not the `dependencyManagement` entry, which correctly stays removed — `confluent-common-bom` already manages `jose4j` transitively).
- Companion fix in progress: a PR against `confluent-security-plugins` (8.0.x) to drop its explicit `${jose4j.version}` reference, so this property can be safely removed from `common` again once that lands and is confirmed safe.

## Test plan
- [ ] CI passes, including CP Jar Build CI Gating (specifically `Build security jar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)