### PR TITLE
[URGENT] Restore jose4j.version property (live regression from #1044)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.36</jetty.version>
+        <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>


### PR DESCRIPTION
## Summary
- **Live regression:** after #1044 merged into `8.0.x`, the `jose4j.version` removal auto-propagated (via `sem-pint` forward-merge, no conflict) through `8.1.x` and `8.2.x`/`8.3.x`.
- Unlike `8.0.x` (where `confluent-security-plugins` doesn't reference `jose4j` at all), `confluent-security-plugins`' `8.1.x`/`8.2.x`/`8.3.x`/`master` all declare an explicit `<dependency>` on `org.bitbucket.b_c:jose4j` versioned via `${jose4j.version}` inherited from `common-parent`. Without the property, Maven fails at POM-parsing time:
  ```
  'dependencies.dependency.version' for org.bitbucket.b_c:jose4j:jar must be a valid version but is '${jose4j.version}'
  ```
- Confirmed via CP Jar Build CI Gating on [common#1045](https://github.com/confluentinc/common/pull/1045) (`Build security jar` failure), and confirmed the property is currently absent from `common`'s live `8.1.x`/`8.2.x`/`8.3.x` branches.
- This restores only the property (not the `dependencyManagement` entry, which correctly stays removed — `confluent-common-bom` already manages `jose4j` transitively).
- Related fixes: [common#1046](https://github.com/confluentinc/common/pull/1046) (8.0.x, defensive/consistency only since `confluent-security-plugins`' 8.0.x doesn't use it), and the same restore already pushed to `pr_merge_from_8_3_x_to_master` (targeting `master`).
- Companion fix in progress: a PR against `confluent-security-plugins` to drop its explicit `${jose4j.version}` reference, so this property can be safely removed from `common` again once confirmed safe across all branches.

## Test plan
- [ ] CI passes, including CP Jar Build CI Gating (`Build security jar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)