### PR TITLE
chore: bump confluent-common-bom to 0.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.2</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.4</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>


### PR DESCRIPTION
## Summary
- Bumps `confluent-common-bom.version` from `0.1.2` to `0.1.4`.
- Checked every property in this pom against confluent-common-bom 0.1.4's managed artifact set (fetched directly from `packages.confluent.io`, comparing by `groupId:artifactId`, not by property name). All overlapping properties already matched the BOM's values, so no other property changes were needed:

| Property | Value | BOM-managed artifact | Aligned? |
|---|---|---|---|
| `commons-io.version` | 2.20.0 | `commons-io:commons-io` | yes |
| `httpclient5.version` | 5.4.4 | `org.apache.httpcomponents.client5:httpclient5` | yes |
| `jose4j.version` | 0.9.6 | `org.bitbucket.b_c:jose4j` | yes |
| `gson.version` | 2.11.0 | `com.google.code.gson:gson` | yes |
| `protobuf.version` | 4.34.0 | `com.google.protobuf:protobuf-java`, `protobuf-java-util` | yes |
| `powermock.version` | 2.0.9 | `org.powermock:powermock-*` | yes |
| `easymock.version` | 5.6.0 | `org.easymock:easymock` | yes |
| `snappy.version` | 1.1.10.8 | `org.xerial.snappy:snappy-java` | yes |
| `logback-core.version` | 1.5.36 | `ch.qos.logback:logback-classic`/`logback-core` | yes |
| `bouncycastle.jdk18.version` | 1.84 | `org.bouncycastle:bcpkix-jdk18on`/`bcprov-jdk18on` | yes |
| `bouncycastle.fips.version` | 2.1.2 | `org.bouncycastle:bc-fips` | yes |
| `bouncycastle.bcutil-fips.version` | 2.1.5 | `org.bouncycastle:bcutil-fips` | yes |
| `bouncycastle.tls-fips.version` | 2.1.22 | `org.bouncycastle:bctls-fips` | yes |
| `bouncycastle.bcpkix-fips.version` | 2.1.10 | `org.bouncycastle:bcpkix-fips` | yes |
| `spotbugs.version` | 4.9.8 | `com.github.spotbugs:spotbugs-annotations` | yes |

Two properties were checked and intentionally left alone as out of scope:
- `netty.version` drives `io.netty:netty-bom` directly (a separate BOM import), not the `grpc-netty`/`grpc-netty-shaded` wrapper artifacts that confluent-common-bom's `grpc-bom` sub-import manages.
- `mockito.version` (4.6.1) is a different artifact (`mockito-core`) from the BOM-managed `org.mockito:mockito-junit-jupiter` (5.23.0) — not the same `groupId:artifactId`.

## Test plan
- [ ] CI build/tests pass on this PR
- Could not run `mvn dependency:tree` locally against the new BOM version (no network access to Confluent's internal CodeArtifact repo from this environment) — verification here was done by diffing the published `confluent-common-bom` 0.1.2→0.1.4 POMs from `packages.confluent.io` against this repo's properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)