### PR TITLE
chore: bump confluent-common-bom to 0.1.4 (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.2</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.4</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -102,9 +102,9 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j2.version>2.25.4</log4j2.version>
+        <log4j2.version>2.25.5</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
-        <logback-core.version>1.5.27</logback-core.version>
+        <logback-core.version>1.5.36</logback-core.version>
         <snappy.version>1.1.10.8</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
         <reload4j.version>1.2.25</reload4j.version>
@@ -237,12 +237,6 @@
               <artifactId>avro</artifactId>
               <version>${avro.version}</version>
             </dependency>
-            <!-- Unify version of commons-io with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
             <!-- Unify version of commons-lang3 with ce-kafka, allow downstream repos to unpin -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -255,12 +249,6 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
             </dependency>
-            <!-- This is to unify the version of Protocol Buffers across CP -->
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
             <!-- Jetty BOM for Jetty 12 -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
@@ -269,26 +257,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- snappy-java is brought in by kafka-clients and its version is specified
-            in ce-kafka -->
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.version}</version>
-            </dependency>
             <!-- we define guava version above, its version is specified
             in ce-kafka, this is for maven projects to use the correct version -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-            </dependency>
-            <!-- ce-kafka brings transitive dependency plexus-utils via maven-artifacts, pin here
-            remove the pin after ce-kafka updates maven-artifacts  -->
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>4.0.3</version>
             </dependency>
             <!-- we define aws-java-sdk azure-identity and azure-storage-blob
             versions, to match the versions in ce-kafka -->
@@ -321,12 +295,6 @@
                 <artifactId>azure-security-keyvault-keys</artifactId>
                 <version>${azure-security-keyvault-keys.version}</version>
             </dependency>
-            <!-- specify version of httpclient5 that is used in ce-kafka for compatibility in maven builds -->
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${httpclient5.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -342,36 +310,6 @@
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${spotbugs.version}</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.jdk18.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.jdk18.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bc-fips</artifactId>
-                <version>${bouncycastle.fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bctls-fips</artifactId>
-                <version>${bouncycastle.tls-fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-fips</artifactId>
-                <version>${bouncycastle.bcpkix-fips.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-fips</artifactId>
-                <version>${bouncycastle.bcutil-fips.version}</version>
             </dependency>
             <!-- Jackson artifacts with individual versioning -->
             <dependency>
@@ -445,14 +383,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
                 <version>${slf4j-reload4j.version}</version>
-            </dependency>
-            <!-- add version definition of logback that is
-            a transitive dependency of ce-kafka -> resource manager
-            This is needed as maven brings back dependency excluded in bazel -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
## Summary
- Bumps `confluent-common-bom.version` from `0.1.2` to `0.1.4` on `8.0.x`.
- Following the pattern from #999, removes `dependencyManagement` entries that now duplicate what the BOM manages at 0.1.4: `commons-io`, `protobuf-java`, `snappy-java`, `plexus-utils`, `httpclient5`, and the 6 BouncyCastle artifacts (`bcpkix-jdk18on`, `bcprov-jdk18on`, `bc-fips`, `bctls-fips`, `bcpkix-fips`, `bcutil-fips`).
- `logback-core` and `log4j-slf4j-impl` were pinned to versions older than the BOM's (`1.5.27` vs `1.5.36`, `2.25.4` vs `2.25.5`). Bumped `logback-core.version`/`log4j2.version` to match the BOM and removed the now-redundant `logback-core` entry.
- `log4j-slf4j-impl`'s local entry is kept (with the version bumped) because it still needs its explicit `runtime` scope — the BOM's entry is unscoped, and removing the local override would change the resolved scope for downstream consumers.
- `spotbugs-annotations`, `easymock`, `powermock-module-junit4`, and `powermock-api-easymock` also keep their local entries: their versions already match the BOM, but they set `provided`/`test` scope that the BOM's unscoped entries don't carry.

## Verification
Ran `mvn help:effective-pom` before/after and confirmed every touched artifact resolves to the intended version and scope (no unintended drift), given the BOM import already takes precedence unless overridden by a local scoped entry.

## Test plan
- [ ] CI build/tests pass on this PR

Supersedes #1051 (which targeted `master` and only bumped the version property without the BOM dedup cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)