### PR TITLE
chore: bump confluent-common-bom to 0.1.5 (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <jackson.version>2.18.9</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
+        <jetty.version>12.0.37</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
@@ -94,6 +95,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
+        <netty.version>4.1.136.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.4</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.5</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -70,7 +70,6 @@
         <jackson.version>2.18.9</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
-        <jetty.version>12.0.36</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
@@ -95,7 +94,6 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.136.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
@@ -249,14 +247,6 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
             </dependency>
-            <!-- Jetty BOM for Jetty 12 -->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>${jetty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- we define guava version above, its version is specified
             in ce-kafka, this is for maven projects to use the correct version -->
             <dependency>
@@ -399,13 +389,6 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>logredactor</artifactId>
                 <version>${logredactor.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
             </dependency>
             <!--this is our own artifacts, but lets others inherit-->
             <dependency>


### PR DESCRIPTION
## Summary

- Bumps `confluent-common-bom.version` from `0.1.4` to `0.1.5`, which adds `jetty-bom`, `jetty-ee10-bom`, and `netty-bom` as managed sub-BOM imports (confluentinc/confluent-common-bom#54).
- Removes `common`'s now-redundant local `jetty-bom`/`netty-bom` **import blocks**, letting confluent-common-bom supply them instead — same rationale as the existing `grpc-bom` centralization.
- **Keeps** the `jetty.version`/`netty.version` **properties** (bumping `jetty.version` to `12.0.37` to match the BOM). See "Fix" section below for why.

## Version changes

| Dependency | Before | After | Why |
|---|---|---|---|
| `jetty-bom`/`jetty-ee10-bom` import | local, `12.0.36` | removed; managed via confluent-common-bom | BOM's managed version is the latest `12.0.x` patch; common was one patch behind |
| `netty-bom` import | local, `4.1.136.Final` | removed; managed via confluent-common-bom | Exact match — zero-version-change centralization |
| `jetty.version` property | `12.0.36` | `12.0.37` (kept) | Still needed directly by downstream consumers (see below); bumped to match the BOM so there's no drift between the property and the BOM-managed entries |
| `netty.version` property | `4.1.136.Final` | `4.1.136.Final` (kept, unchanged) | Same reason |

## Fix: first attempt broke rest-utils

The first version of this PR also removed the `jetty.version`/`netty.version` **properties**, not just the import blocks. A `cp-jar-build` CI run against this branch showed that broke `rest-utils`, which declares its own dependencies with `<version>${jetty.version}</version>` / `${netty.version}` directly (not via unversioned BOM-managed deps) and has no local override — removing the properties made those resolve to an empty string:
```
'dependencies.dependency.version' for org.eclipse.jetty:jetty-server:jar must be a valid version but is ''
```
(17 similar errors across jetty-*/jetty-ee10-*/netty-* artifacts). The import blocks themselves were never implicated in that failure — only the properties were load-bearing. This PR now keeps the properties and only removes the local import blocks.

(A separate, unrelated `ce-kafka` build failure in the same CI run — a Java generics/type-inference compile error in `MultiTenantApisTest.java` — appears pre-existing on `8.0.x` and unrelated to this change.)

## Downstream inheritance check

Audited every repo that inherits `common`/`common-parent` to confirm none silently relies on inheriting `${jetty.version}`/`${netty.version}` without a local override:

- `cc-cluster-upgrader`, `cc-flink-autopilot`, `cc-rbac-services` (+ submodules), `cc-usage-aggregator`, `ide-sidecar`, `mcm-orchestrator`, `schroedinger`, `cc-kafka-platform-manager` — all define their own local override. Unaffected.
- `kafka-connect-storage-common` → `kafka-connect-storage-cloud` — local override at the `kafka-connect-storage-common` level shadows before reaching `common`. Unaffected.
- 17 other `common-parent` inheritors checked — none reference either property.
- `rest-utils` (and its downstream family) has no local override, but since we now keep the properties, it's unaffected by this PR.

## Test plan
- [x] `mvn install` (full reactor, skip tests/checkstyle/spotbugs) — 0 errors
- [x] Confirmed `jetty-bom:12.0.37` and `netty-bom:4.1.136.Final` were fetched into `.m2` via the BOM import
- [x] `cp-jar-build` CI run against this branch — `rest-utils`/`common-docker` failures from the first attempt fixed; re-running to confirm
- [ ] CI build/tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)