### PR TITLE
chore: bump confluent-common-bom to 0.1.6 (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.5</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.6</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -67,7 +67,8 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.18.9</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
+        <jackson.annotations.version>2.22</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.37</jetty.version>
@@ -302,14 +303,6 @@
                 <artifactId>spotbugs-annotations</artifactId>
                 <version>${spotbugs.version}</version>
                 <scope>provided</scope>
-            </dependency>
-            <!-- Jackson artifacts with individual versioning -->
-            <dependency>
-              <groupId>com.fasterxml.jackson</groupId>
-              <artifactId>jackson-bom</artifactId>
-              <version>${jackson.version}</version>
-              <scope>import</scope>
-              <type>pom</type>
             </dependency>
             <!-- We fix the scala version to prevent downstream projects from bringing in
             different minor versions of Scala via different dependencies -->


### PR DESCRIPTION
## Summary

- Bumps `confluent-common-bom.version` from `0.1.5` to `0.1.6`, which adds `jackson-bom` as a managed sub-BOM import (confluentinc/confluent-common-bom#55).
- Removes `common`'s now-redundant local `jackson-bom` **import block**, letting confluent-common-bom supply it instead — same rationale as the existing `grpc-bom`/`jetty-bom`/`netty-bom` centralizations (see #1065).
- **Keeps** the `jackson.version` **property** (bumped `2.18.9` -> `2.22.1` to match the BOM) and **adds** `jackson.annotations.version` (`2.22`) as a new property, since downstream consumers may inherit these directly without a local override — same rationale as #1065 keeping `jetty.version`/`netty.version`.

## Version changes

| Dependency | Before | After | Why |
|---|---|---|---|
| `jackson-bom` import | local, `2.18.9` | removed; managed via confluent-common-bom | confluent-common-bom's jackson-bom import (added in 0.1.6) is imported before `common`'s own local import in this pom, so it already wins on "first import wins" — removing the now-dead local import is just cleanup |
| `jackson.version` property | `2.18.9` | `2.22.1` (kept) | Still needed directly by downstream consumers (see below); bumped to match the BOM so there's no drift between the property and the BOM-managed entries |
| `jackson.annotations.version` property | n/a | `2.22` (new) | `jackson-annotations` stopped publishing patch versions at 2.20 (only bare `2.20`/`2.21`/`2.22` exist) unlike the rest of the jackson family, so it needs its own property — same pattern `common`'s `master` branch and `resource-manager` already use |

## Downstream inheritance check

Audited known `common`/`common-parent` inheritors that track the `8.0.x` line specifically (repos pinned to a newer `common` version range, e.g. most `cc-*` cloud services, don't consume this branch at all and are unaffected):

- `rest-utils` (8.0.x) — no local override, doesn't reference `${jackson.version}` directly itself. Unaffected, just passes the property through.
- `schema-registry` (8.0.x) — 6 deps (`jackson-dataformat-csv`, `jackson-datatype-guava`/`jdk8`/`joda`/`jsr310`, `jackson-module-parameter-names`) pinned via `${jackson.version}`, no local override. All confirmed to publish matching `2.22.1` releases on Maven Central. Unaffected.
- `kafka-rest` (8.0.x) — 2 deps (`jackson-datatype-jdk8`/`guava`), same story. Unaffected.
- `kafka-streams-examples` (8.0.x) — pins `jackson-annotations` via `${jackson.version}` directly (no separate annotations property, no override). This **will break** once `jackson.version` crosses 2.20, since `jackson-annotations` doesn't publish matching patch versions past that point — there's no single value of `jackson.version` that satisfies both `jackson-core`/`jackson-databind` (need a patch version) and `jackson-annotations` (needs a bare major.minor) simultaneously. This is being tracked/fixed separately in that repo (switching it to a dedicated annotations property), not part of this PR.

This check is based on the known-inheritor list from #1065 plus the standard CP `8.0.x`-line repos (`schema-registry`, `kafka-rest`, `ksql`, `common-docker`, `kafka-streams-examples`) — not an exhaustive org-wide audit.

## Test plan
- [x] `mvn validate` (full reactor) — 0 errors
- [x] `mvn help:effective-pom` — confirmed `jackson-core`/`jackson-databind` resolve to `2.22.1` and `jackson-annotations` resolves to `2.22`, all sourced via confluent-common-bom's `jackson-bom`
- [ ] CI build/tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)