### PR TITLE
[Common BOM] Bump confluent-common-bom to 0.1.8 (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.6</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.7</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -92,6 +92,9 @@
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
+        <!-- Unused here now that confluent-common-bom manages mockito-core and
+             mockito-junit-jupiter, but inherited by downstream repos (rest-utils,
+             parallel-consumer, ksql) that reference ${mockito.version} directly. -->
         <mockito.version>4.6.1</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
@@ -445,13 +448,6 @@
                 <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>${mockito.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -448,13 +448,6 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>${mockito.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
                 <version>${mockito-all.version}</version>
                 <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,6 @@
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
-        <!-- Deliberately left at 4.6.1, below the 5.23.0 confluent-common-bom manages.
-             Nothing here uses it, but rest-utils, ksql, and kafka-connect-elasticsearch
-             inherit this property and pin mockito against it directly. Moving it to 5.x
-             needs rest-utils and kafka-connect-elasticsearch to drop mockito-inline
-             first: that artifact stops at 5.2.0, since Mockito 5 makes the inline mock
-             maker the default. -->
         <mockito.version>4.6.1</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
@@ -451,6 +445,13 @@
                 <artifactId>powermock-api-mockito2</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,12 @@
         <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
-        <!-- Unused here now that confluent-common-bom manages mockito-core and
-             mockito-junit-jupiter, but inherited by downstream repos (rest-utils,
-             parallel-consumer, ksql) that reference ${mockito.version} directly. -->
+        <!-- Deliberately left at 4.6.1, below the 5.23.0 confluent-common-bom manages.
+             Nothing here uses it, but rest-utils, ksql, and kafka-connect-elasticsearch
+             inherit this property and pin mockito against it directly. Moving it to 5.x
+             needs rest-utils and kafka-connect-elasticsearch to drop mockito-inline
+             first: that artifact stops at 5.2.0, since Mockito 5 makes the inline mock
+             maker the default. -->
         <mockito.version>4.6.1</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.7</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.8</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>


### PR DESCRIPTION
## Summary

Bumps `confluent-common-bom` 0.1.6 → 0.1.8 and drops the now-redundant local `mockito-bom` import.

## What changed

| | |
|---|---|
| `confluent-common-bom.version` | 0.1.6 → **0.1.8** |
| `org.mockito:mockito-bom` import | **removed** (superseded, see below) |
| `mockito.version` property | **kept** at 4.6.1, with a comment explaining why |

## What the 0.1.7 bump fixed

0.1.7 adds `org.mockito:mockito-core` alongside the `mockito-junit-jupiter` the BOM already managed. Because the `confluent-common-bom` import sits at line 236 and the local `mockito-bom` at line 457, first-import-wins means the BOM now supplies both:

| | before (0.1.6) | after (0.1.7+) |
|---|---|---|
| `mockito-junit-jupiter` | 5.23.0 (BOM) | 5.23.0 |
| `mockito-core` | **4.6.1** (mockito-bom) | **5.23.0** |

## What the 0.1.8 bump adds

0.1.8 (https://github.com/confluentinc/confluent-common-bom/pull/57) only bumps `lz4-java` to 1.11.2. `common` doesn't depend on `lz4-java` directly, so no other `pom.xml` changes were needed for this hop — just the version bump.

## Verification

- `mvn help:effective-pom`: `confluent-common-bom.version` resolves to 0.1.8; `mockito-core`/`mockito-junit-jupiter` both resolve to 5.23.0 (unchanged from the 0.1.7 state).
- `mvn -N validate` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)