### PR TITLE
chore: bump confluent-common-bom to 0.1.9 (8.0.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.6</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.9</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
@@ -56,7 +56,7 @@
         <azure-identity.version>1.17.0</azure-identity.version>
         <azure-storage.version>12.31.2</azure-storage.version>
         <azure-security-keyvault-keys.version>4.10.7</azure-security-keyvault-keys.version>
-        <httpclient5.version>5.4.4</httpclient5.version>
+        <httpclient5.version>5.6.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.0.8-0-ccs, 8.0.9-0-ccs)</kafka.version>
         <ce.kafka.version>[8.0.8-0-ce, 8.0.9-0-ce)</ce.kafka.version>


### PR DESCRIPTION
## Summary
- Bumps `confluent-common-bom.version` from `0.1.6` to `0.1.9`.
- Bumps the local `httpclient5.version` compat property from `5.4.4` to `5.6.4` to match — `confluent-common-bom` 0.1.9 was published to fix CVE-2026-71290 via confluentinc/confluent-common-bom#58, and this property is kept in `common`'s pom purely for downstream inheritance (not consumed by a `<dependency>` entry in `common` itself), so it needs to move in step with the BOM to avoid handing downstream consumers a stale, pre-CVE-fix version.

## Verification
- No network access to Confluent's internal artifact repo from this environment, so `mvn help:effective-pom` / `dependency:tree` verification could not be run — flagging per the propagation-skill convention rather than skipping silently.
- Diff is a 2-line property-value change only; no `<dependency>` entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)