### PR TITLE
Resolve pom.xml merge conflict for 8.4.x -> master pint merge

### DIFF
--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.4.0-0</version>
+    <version>8.5.0-0</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>
@@ -49,17 +49,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.9.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.4.0-0</version>
+    <version>8.5.0-0</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 
@@ -44,12 +44,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.9.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.4.0-0</version>
+    <version>8.5.0-0</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -50,22 +50,22 @@
         <commons-io.version>2.20.0</commons-io.version>
         <confluent-common-bom.version>0.1.9</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
-        <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
-        <aws-java-sdk-v2.version>2.29.39</aws-java-sdk-v2.version>
-        <azure-identity.version>1.17.0</azure-identity.version>
-        <azure-storage.version>12.31.2</azure-storage.version>
-        <azure-security-keyvault-keys.version>4.10.7</azure-security-keyvault-keys.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <aws-java-sdk.version>1.12.797</aws-java-sdk.version>
+        <aws-java-sdk-v2.version>2.52.1</aws-java-sdk-v2.version>
+        <azure-identity.version>1.18.4</azure-identity.version>
+        <azure-storage.version>12.35.0</azure-storage.version>
+        <azure-security-keyvault-keys.version>4.11.1</azure-security-keyvault-keys.version>
         <httpclient5.version>5.6.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.4.0-0-0-ccs, 8.4.1-0-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.4.0-0-0-ce, 8.4.1-0-0-ce)</ce.kafka.version>
+        <kafka.version>[8.5.0-0-0-ccs, 8.5.1-0-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.5.0-0-0-ce, 8.5.1-0-0-ce)</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
-        <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
-        <spotbugs.version>4.9.8</spotbugs.version>
-        <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <spotbugs.version>4.10.3</spotbugs.version>
+        <spotbugs.maven.plugin.version>4.10.3.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.22.1</jackson.version>
         <jackson.annotations.version>2.22</jackson.annotations.version>
@@ -75,28 +75,28 @@
         <jetty.version>12.0.37</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
         <gson.version>2.11.0</gson.version>
-        <guava.version>32.0.1-jre</guava.version>
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <guava.version>32.1.3-jre</guava.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>
-        <junit.jupiter.version>5.13.1</junit.jupiter.version>
+        <junit.jupiter.version>5.14.4</junit.jupiter.version>
         <kafka.scala.version>2.13</kafka.scala.version>
-        <scala.version>2.13.11</scala.version>
-        <maven-assembly.version>3.3.0</maven-assembly.version>
-        <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
+        <scala.version>2.13.18</scala.version>
+        <maven-assembly.version>3.8.0</maven-assembly.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <maven-deploy.version>2.8.2</maven-deploy.version>
-        <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-        <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
-        <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+        <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
+        <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <mbknor-jackson-jsonschema.version>1.0.39</mbknor-jackson-jsonschema.version>
         <buildnumber-plugin.version>1.4</buildnumber-plugin.version>
-        <mockito.version>4.6.1</mockito.version>
+        <mockito.version>4.11.0</mockito.version>
         <mockito-all.version>1.10.19</mockito-all.version>
-        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-        <jaxb.version>2.3.0</jaxb.version>
+        <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
+        <jaxb.version>2.3.1</jaxb.version>
         <netty.version>4.1.137.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>4.34.0</protobuf.version>
@@ -104,12 +104,12 @@
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j2.version>2.25.5</log4j2.version>
+        <log4j2.version>2.26.1</log4j2.version>
         <slf4j-reload4j.version>1.7.36</slf4j-reload4j.version>
         <logback-core.version>1.5.36</logback-core.version>
         <snappy.version>1.1.10.8</snappy.version>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-reload4j/1.7.36 -->
-        <reload4j.version>1.2.25</reload4j.version>
+        <reload4j.version>1.2.26</reload4j.version>
         <logredactor.version>1.0.18</logredactor.version>
         <bouncycastle.jdk18.version>1.84</bouncycastle.jdk18.version>
         <!-- before updating bouncycastle.fips.version make sure
@@ -122,10 +122,10 @@
         <jmx_prometheus_javaagent.version>0.20.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>
-        <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+        <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <checkstyle.config.location>checkstyle/checkstyle.xml</checkstyle.config.location>
         <checkstyle.suppressions.location>checkstyle/common-suppressions.xml</checkstyle.suppressions.location>
         <dependency.check.version>7.4.4</dependency.check.version>
@@ -152,7 +152,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.4.0-0</io.confluent.common.version>
+        <io.confluent.common.version>8.5.0-0</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -162,7 +162,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.4.0-0, 8.4.1-0)</confluent.version.range>
+        <confluent.version.range>[8.5.0-0, 8.5.1-0)</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.
@@ -877,7 +877,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>${custom.deploy.phase}</phase>
@@ -900,7 +900,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.9.0</version>
+                <version>2.9.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -1386,7 +1386,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.48.1</version>
+                        <version>0.49.0</version>
                       <executions>
                         <execution>
                           <phase>package</phase>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.4.0-0</version>
+        <version>8.5.0-0</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## What is this pull request?

PR #1077 (pint's autogenerated merge-conflict-resolution PR for 8.4.x -> master) is marked CONFLICTING. This PR resolves that conflict on the `pr_merge_from_8_4_x_to_master` branch so #1077 becomes mergeable.

## The conflict

Both `master` and `8.4.x` bumped `confluent-common-bom.version` (0.1.6 -> 0.1.9) and `httpclient5.version` (5.4.4 -> 5.6.4) to the same values, so those lines merge cleanly. The reported conflict is actually on the adjacent block: `master` independently bumped `commons-lang3`, `aws-java-sdk`, `aws-java-sdk-v2`, `azure-identity`, `azure-storage`, and `azure-security-keyvault-keys` versions (via #751), while `8.4.x` never touched those properties. The overlapping hunks caused git to flag the whole block as conflicting.

## Resolution

Kept `master`'s (newer) values for the six dependency properties `8.4.x` didn't touch. Verified the resulting merge tree is byte-identical to `origin/master`'s `pom.xml` (git worktree, `git diff origin/master -- pom.xml` produced no output) — confirming every real change `8.4.x` introduced was already present on master.

## Next steps

1. Merge this PR into `pr_merge_from_8_4_x_to_master`
2. #1077 should then show as mergeable — merge it into `master` using **"Create a merge commit"**
3. Re-run [pint merge](http://go/pint-merge-service)