### PR TITLE
Bump confluent-common-bom to 0.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,8 @@
         <argLine></argLine>
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
-        <confluent-common-bom.version>0.1.9</confluent-common-bom.version>
+        <confluent-common-bom.version>0.1.10</confluent-common-bom.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
         <aws-java-sdk-v2.version>2.29.39</aws-java-sdk-v2.version>
         <azure-identity.version>1.17.0</azure-identity.version>
@@ -243,12 +242,6 @@
               <groupId>org.apache.avro</groupId>
               <artifactId>avro</artifactId>
               <version>${avro.version}</version>
-            </dependency>
-            <!-- Unify version of commons-lang3 with ce-kafka, allow downstream repos to unpin -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
             </dependency>
             <!-- Pin version of commons-beanutils as it is used transitively not only by commons-validator -->
             <dependency>


### PR DESCRIPTION
## Summary
- Bump `confluent-common-bom.version` from 0.1.9 to 0.1.10 on the `8.0.x` branch.
- Drop the local `commons-lang3` pin (was 3.18.0, carried the comment "Unify version of commons-lang3 with ce-kafka, allow downstream repos to unpin") now that confluent-common-bom 0.1.10 newly manages `org.apache.commons:commons-lang3` at 3.20.0. No scope override existed on this entry, so it's a clean removal.

## What changed between 0.1.9 and 0.1.10
Diffed the published poms directly:
- `netty.version`: 4.1.136.Final → 4.1.137.Final. `common`'s own `netty.version` property (4.1.137.Final) already matched the new value and isn't referenced anywhere in this repo's own `dependencyManagement` (likely inherited by downstream repos via `common-parent`), so no edit was needed there.
- New managed artifact: `org.apache.commons:commons-lang3` at 3.20.0 (see above).

## What was checked and kept unchanged
Every other BOM-managed artifact `common` also pins locally was checked by exact `groupId:artifactId` against the 0.1.10 BOM's pom and left as-is because it carries a scope override the BOM's own (unscoped) entry doesn't, and its version already matches the BOM:
- `org.easymock:easymock` (test scope, 5.6.0)
- `org.powermock:powermock-api-easymock`, `org.powermock:powermock-module-junit4` (test scope, 2.0.9)
- `org.apache.logging.log4j:log4j-slf4j-impl` (runtime scope, 2.25.5)
- `com.github.spotbugs:spotbugs-annotations` (provided scope, 4.9.8)

## Verification
- `mvn help:effective-pom` before/after: confirmed `commons-lang3` now resolves to 3.20.0 from the BOM (no duplicate/local entry), and all five scope-overridden dependencies above resolve to their expected version *and* scope post-bump. Network access to Confluent's internal artifact repo was available in this environment, so this ran successfully.