### PR TITLE
Remove unused httpclient5.version and gson.version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <azure-identity.version>1.17.0</azure-identity.version>
         <azure-storage.version>12.31.2</azure-storage.version>
         <azure-security-keyvault-keys.version>4.10.7</azure-security-keyvault-keys.version>
-        <httpclient5.version>5.6.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.0.8-0-ccs, 8.0.9-0-ccs)</kafka.version>
         <ce.kafka.version>[8.0.8-0-ce, 8.0.9-0-ce)</ce.kafka.version>
@@ -74,7 +73,6 @@
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.37</jetty.version>
         <jose4j.version>0.9.6</jose4j.version>
-        <gson.version>2.11.0</gson.version>
         <guava.version>32.0.1-jre</guava.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
## Summary
- Drop `httpclient5.version` (5.6.4) and `gson.version` (2.11.0) from the root `pom.xml` properties.
- Both are already managed by `confluent-common-bom` 0.1.9 (current on this branch) at the identical values, and `common` has no local `dependencyManagement` entry for either — they were pure leftover duplicates. No BOM bump needed for this change.
- Verified no downstream consumer inherits either property: known consumers of `gson.version` (`bamboo`, `confluent-cloud-plugins`, `kafka-connect-elasticsearch`) and `httpclient5.version` (`schroedinger`) all pin their own local value.

## Test plan
- [ ] CI build passes on this branch
- [ ] `mvn help:effective-pom` confirms `gson`/`httpclient5` still resolve (from the BOM) at the same versions as before