### PR TITLE
Add OpenTelemetry BOM to ensure uniform version of libraries being used in maven builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.137.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <opentelemetry.version>1.65.0</opentelemetry.version>
         <protobuf.version>3.25.5</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
@@ -279,6 +280,14 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
                 <version>1.75.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- OpenTelemetry version override -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Add OpenTelemetry BOM to ensure uniform version of libraries being used in maven builds