### PR TITLE
Remove unused commons-beanutils version pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <avro.version>1.12.1</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
         <confluent-common-bom.version>0.1.10</confluent-common-bom.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <aws-java-sdk.version>1.12.746</aws-java-sdk.version>
         <aws-java-sdk-v2.version>2.29.39</aws-java-sdk-v2.version>
         <azure-identity.version>1.17.0</azure-identity.version>
@@ -251,12 +250,6 @@
               <groupId>org.apache.avro</groupId>
               <artifactId>avro</artifactId>
               <version>${avro.version}</version>
-            </dependency>
-            <!-- Pin version of commons-beanutils as it is used transitively not only by commons-validator -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>${commons-beanutils.version}</version>
             </dependency>
             <!-- we define guava version above, its version is specified
             in ce-kafka, this is for maven projects to use the correct version -->


### PR DESCRIPTION
## Summary
- Removes the `commons-beanutils.version` property and the `commons-beanutils:commons-beanutils` dependencyManagement entry from `common`'s own `pom.xml`.

## Why this is safe
- Nothing in `common` pulls in `commons-beanutils`, directly or transitively — confirmed via `dependency:tree` across every module in the reactor (root, `utils`, `metrics`, `config`, `logging`, `log4j-extensions`, `log4j2-extensions`, `disk-usage-agent`, `build-tools`, `package`): zero matches for `beanutils` anywhere.
- The removed entry's own comment says it exists because `commons-beanutils` is used transitively by `commons-validator` — but `commons-validator` isn't a dependency anywhere in this repo, so the comment is stale and the pin is dead weight.
- `hub-client`, the only known consumer downstream, pins its own `commons-beanutils.version` (1.11.0) and its own dependencyManagement entry directly in its own `pom.xml`, identically on every branch (`8.0.x`–`8.4.x`, `master`). It does not rely on `common` to supply this version, so removing it here has no effect on `hub-client`.

## Note
- confluent-common-bom 0.1.11 (see #1090) now also manages `commons-beanutils` at the same version (1.11.0), which will supply it going forward if anything in `common` or a downstream consumer ever needs it again.

## Verification
- `mvn validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)