### PR TITLE
[7.9.x] Add OpenTelemetry BOM to ensure uniform version of libraries being used in maven builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <jaxb.version>2.3.0</jaxb.version>
         <netty.version>4.1.137.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <opentelemetry.version>1.65.0</opentelemetry.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
         <protobuf.version>3.25.5</protobuf.version>
@@ -290,6 +291,14 @@
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio-jvm</artifactId>
                 <version>${okio.version}</version>
+            </dependency>
+            <!-- OpenTelemetry version override -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- This is to unify the version of Protocol Buffers across CP -->
             <dependency>


### PR DESCRIPTION
Add OpenTelemetry BOM to ensure uniform version of libraries being used in maven builds.

Mirrors #1087.