### PR TITLE
CPBR-3841: Bump jmx_prometheus_javaagent.version from 0.20.0 to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,10 @@
         <bouncycastle.bcutil-fips.version>2.1.5</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.1.22</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.10</bouncycastle.bcpkix-fips.version>
+        <!-- jmx_exporter stopped publishing to Maven Central after 1.0.1 - versions >=1.1.0
+             must be fetched directly from GitHub Releases instead, e.g.:
+             https://github.com/prometheus/jmx_exporter/releases/download/${jmx_prometheus_javaagent.version}/jmx_prometheus_javaagent-${jmx_prometheus_javaagent.version}.jar
+             (see common-docker's base-java/Dockerfile.ubi9 for the curl-fetch + sha256-verify pattern) -->
         <jmx_prometheus_javaagent.version>1.6.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <bouncycastle.bcutil-fips.version>2.1.5</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.1.22</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.10</bouncycastle.bcpkix-fips.version>
-        <jmx_prometheus_javaagent.version>0.20.0</jmx_prometheus_javaagent.version>
+        <jmx_prometheus_javaagent.version>1.6.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,9 @@
         <bouncycastle.bcutil-fips.version>2.1.5</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.1.22</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.10</bouncycastle.bcpkix-fips.version>
-        <!-- jmx_exporter stopped publishing to Maven Central after 1.0.1 - versions >=1.1.0
-             must be fetched directly from GitHub Releases instead, e.g.:
-             https://github.com/prometheus/jmx_exporter/releases/download/${jmx_prometheus_javaagent.version}/jmx_prometheus_javaagent-${jmx_prometheus_javaagent.version}.jar
-             (see common-docker's base-java/Dockerfile.ubi9 for the curl-fetch + sha256-verify pattern) -->
+        <!-- jmx_exporter is GitHub Releases-only for >=1.1.0 (Maven Central stopped after 1.0.1).
+             Fetch: github.com/prometheus/jmx_exporter/releases/download/<version>/jmx_prometheus_javaagent-<version>.jar
+             (curl-fetch + sha256-verify pattern: common-docker's base-java/Dockerfile.ubi9). -->
         <jmx_prometheus_javaagent.version>1.6.0</jmx_prometheus_javaagent.version>
         <jolokia-jvm.version>1.7.1</jolokia-jvm.version>
         <checkstyle.version>9.3</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <bouncycastle.bcutil-fips.version>2.1.5</bouncycastle.bcutil-fips.version>
         <bouncycastle.tls-fips.version>2.1.22</bouncycastle.tls-fips.version>
         <bouncycastle.bcpkix-fips.version>2.1.10</bouncycastle.bcpkix-fips.version>
-        <!-- jmx_exporter is GitHub Releases-only for >=1.1.0 (Maven Central stopped after 1.0.1).
+        <!-- jmx_prometheus_javaagent is GitHub Releases-only for >=1.1.0 (Maven Central stopped after 1.0.1).
              Fetch: github.com/prometheus/jmx_exporter/releases/download/<version>/jmx_prometheus_javaagent-<version>.jar
              (curl-fetch + sha256-verify pattern: common-docker's base-java/Dockerfile.ubi9). -->
         <jmx_prometheus_javaagent.version>1.6.0</jmx_prometheus_javaagent.version>


### PR DESCRIPTION
## Summary
- Bumps `jmx_prometheus_javaagent.version` from `0.20.0` to `1.6.0`.

## Who consumes this property from common's 8.4.x branch
- **common-docker** (`base-java`/`base-java-micro`) — bundles the jar into the CP base image. All per-component CP images (`cp-server`, `cp-kafka`, `cp-schema-registry`, etc.) inherit it via `FROM`. **confluent-operator**'s init-container attaches it at runtime via `-javaagent:`, globbing the jar off the filesystem - no Maven involved there ([components/controlcenter/bin/launch#L70-L85](https://github.com/confluentinc/confluent-operator/blob/e18ec8fcb34de3642960a4e923c9a353f3d2f841/init-container/components/controlcenter/bin/launch#L70-L85)):
  ```sh
  jmx-prometheus-agent(){
     if [ -e "/mnt/config/shared/jmx-exporter.yaml" ]; then
        PROMETHEUS_DIR="/usr/share/java/cp-base-new"
        PROMETHEUS=("${PROMETHEUS_DIR}/jmx_prometheus_javaagent-"*.jar)
        export CONTROL_CENTER_OPTS="${CONTROL_CENTER_OPTS} -javaagent:${PROMETHEUS[0]}=${JMX_EXPORTER_AGENT_PORT}:/mnt/config/shared/jmx-exporter.yaml"
    fi
  }
  ```
  The glob (`jmx_prometheus_javaagent-"*.jar`) means it picks up whatever version is present 
- **control-center-next-gen-images** — packages the jar directly into the C3 image.
-  gateway-images's confluent-gateway-for-cloud module also resolves this via Maven, but is pinned to common [8.2.2-0, 8.2.3-0) - unaffected by this common bump to the 8.4.x range, but it'll need the same curl-fetch migration before its own common pin ever advances into that range.

## Validation
We temporarily hardcoded `1.6.0` in `common-docker` ([common-docker#2460](https://github.com/confluentinc/common-docker/pull/2460)), built all CP images on it, and ran the full CFK e2e suite:
- Test run: https://semaphore.ci.confluent.io/workflows/9f43f108-b0f8-42f2-bbfc-a1721416e347?pipeline_id=db7bf47a-85db-4eb9-85e2-a223e4d78f73
- Slack sign-off: https://confluent.slack.com/archives/C08AD5ZE7PV/p1788326454575509?thread_ts=1786513717.041699&cid=C08AD5ZE7PV

The test failures came here , all also present in the nightly 8.4.x baseline — zero jmx-caused regressions.

## Alternatives considered
We considered mirroring the jar into internal CodeArtifact (the same pattern used for Jetty 9) and letting downstream consumers resolve it from there via Maven. We chose direct GitHub Releases downloads in each consumer repo instead because
- `jmx_prometheus_javaagent` is distributed by upstream as an application, not a library, and was never intended to be resolved as a normal Maven artifact - mirroring it into CodeArtifact would still treat it as one.

## Next step
-  https://confluentinc.atlassian.net/browse/DOCS-43029 we need to inform customer about this new jmx version being shippped with cp in release notes, created a docs ticket for that 
- [`control-center-next-gen-images#471`](https://github.com/confluentinc/control-center-next-gen-images/pull/471) switches from a Maven `<dependency>` to a direct curl-fetch from GitHub Releases, inheriting this version. We'll merge it right after this PR merges.
- Once this PR merges, remove common-docker's temporary hardcoded override (common-docker#2460 (https://github.com/confluentinc/common-docker/pull/2460)) and let it inherit ${jmx_prometheus_javaagent.version} from common directly.

