### PR TITLE
Remove unused easymock.version pin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <required.maven.version>3.2</required.maven.version>
         <kafka.version>[8.0.8-0-ccs, 8.0.9-0-ccs)</kafka.version>
         <ce.kafka.version>[8.0.8-0-ce, 8.0.9-0-ce)</ce.kafka.version>
-        <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
@@ -423,12 +422,6 @@
                 <version>${junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.easymock</groupId>
-                <artifactId>easymock</artifactId>
-                <version>${easymock.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>


### PR DESCRIPTION
## Summary
- Removes the `easymock.version` property and its `org.easymock:easymock` `dependencyManagement` entry from `common`'s root `pom.xml`.
- `confluent-common-bom` 0.1.10 (already imported here) manages `org.easymock:easymock` at the same `5.6.0` version, so this pin is redundant — same resolved version either way.
- No repo on the 8.x/master release train inherits `easymock.version` from this branch of `common`. The one downstream reference found (`kafka-connect-storage-cloud`) resolves through an unrelated, pre-BOM `common` release (`7.7.x`) via its own parent chain (`kafka-connect-storage-common-parent`), so removing this from `8.0.x` doesn't affect it.

## Verification
- `mvn -N validate` passes
- No `.java` or `pom.xml` file in this repo references `easymock`/`EasyMock` directly — the entry only existed to supply downstream consumers, which the BOM already covers.

## Tracking
Part of the BOM-migration cleanup identified in the [Common Inheritance Map](https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82) audit — `easymock.version` was the property with the fewest downstream repos (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)