### PR TITLE
Resolve merge conflict for #1103 (8.0.x -> 8.1.x)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -58,8 +58,8 @@ blocks:
           commands:
             - ci-tools ci-update-version --direct-pom-edit
             - ci-tools ci-push-tag
-            - mvn -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode 
-              -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/ 
+            - mvn -Pjenkins -U -Dmaven.wagon.http.retryHandler.count=10 --batch-mode
+              -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/
               -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests
   - name: CP Jar Build CI Gating
     dependencies: []
@@ -113,7 +113,6 @@ after_pipeline:
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
               sem-trigger -p rest-utils -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p newwave -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-connect-replicator -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p hub-client -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.3-0</version>
+    <version>8.1.4-0</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.5-0</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.4</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.5</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/assembly-plugin-boilerplate/pom.xml
+++ b/assembly-plugin-boilerplate/pom.xml
@@ -24,7 +24,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <groupId>io.confluent</groupId>
     <artifactId>assembly-plugin-boilerplate</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.5-0</version>
+    <version>8.1.6-0</version>
     <name>${project.artifactId}</name>
     <description>Maven Assembly Plugin boilerplate for Dockerized projects</description>
     <url>https://github.com/confluentinc/common</url>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.1.3-0</version>
+    <version>8.1.4-0</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.1.4-0</version>
+    <version>8.1.5-0</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.1.4-0</version>
+    <version>8.1.4</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.1.5-0</version>
+    <version>8.1.6-0</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>8.1.4-0</version>
+    <version>8.1.5</version>
     <name>Build Tools</name>
     <url>https://github.com/confluentinc/common</url>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <artifactId>common-config</artifactId>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <properties>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <properties>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <properties>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <properties>

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <properties>

--- a/log4j-extensions/pom.xml
+++ b/log4j-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <properties>

--- a/log4j2-extensions/pom.xml
+++ b/log4j2-extensions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <properties>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <properties>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <artifactId>common-metrics</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <artifactId>common-package</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.3-0</version>
+    <version>8.1.4-0</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -61,8 +61,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.1.3-0-ccs, 8.1.4-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.1.3-0-ce, 8.1.4-0-ce)</ce.kafka.version>
+        <kafka.version>[8.1.4-0-ccs, 8.1.5-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.1.4-0-ce, 8.1.5-0-ce)</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -157,7 +157,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.1.3-0</io.confluent.common.version>
+        <io.confluent.common.version>8.1.4-0</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -167,7 +167,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.1.3-0, 8.1.4-0)</confluent.version.range>
+        <confluent.version.range>[8.1.4-0, 8.1.5-0)</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.19.4</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.35</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.4</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -62,8 +62,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.1.4-0-ccs, 8.1.5-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.1.4-0-ce, 8.1.5-0-ce)</ce.kafka.version>
+        <kafka.version>8.1.4-ccs</kafka.version>
+        <ce.kafka.version>8.1.4-ce</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -159,7 +159,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.1.4-0</io.confluent.common.version>
+        <io.confluent.common.version>8.1.4</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -169,7 +169,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.1.4-0, 8.1.5-0)</confluent.version.range>
+        <confluent.version.range>8.1.4</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.5-0</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -62,8 +62,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.1.4-0-ccs, 8.1.5-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.1.4-0-ce, 8.1.5-0-ce)</ce.kafka.version>
+        <kafka.version>[8.1.5-0-ccs, 8.1.6-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.1.5-0-ce, 8.1.6-0-ce)</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -159,7 +159,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.1.4-0</io.confluent.common.version>
+        <io.confluent.common.version>8.1.5-0</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -169,7 +169,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.1.4-0, 8.1.5-0)</confluent.version.range>
+        <confluent.version.range>[8.1.5-0, 8.1.6-0)</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.21.2</jackson.version>
+        <jackson.annotations.version>2.21</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.35</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.19.4</jackson.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <jetty.version>12.0.35</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>
-        <protobuf.version>4.34.0</protobuf.version>
+        <protobuf.version>4.32.1</protobuf.version>
         <powermock.version>2.0.9</powermock.version>
         <!-- Potentially used by downstream projects -->
         <slf4j-api.version>${slf4j.version}</slf4j-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <!-- okio version to match ce-kafka 7.8.x -->
         <okio.version>3.7.0</okio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotbugs.maven.plugin.version>4.9.8.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <jackson.annotations.version>2.21</jackson.annotations.version>
         <jakarta-websocket-api.version>2.2.0</jakarta-websocket-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.4-0</version>
+    <version>8.1.5</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -62,8 +62,8 @@
         <azure-security-keyvault-keys.version>4.10.3</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.1.4-0-ccs, 8.1.5-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.1.4-0-ce, 8.1.5-0-ce)</ce.kafka.version>
+        <kafka.version>8.1.5-ccs</kafka.version>
+        <ce.kafka.version>8.1.5-ce</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -159,7 +159,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.1.4-0</io.confluent.common.version>
+        <io.confluent.common.version>8.1.5</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -169,7 +169,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.1.4-0, 8.1.5-0)</confluent.version.range>
+        <confluent.version.range>8.1.5</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>common-parent</artifactId>
     <packaging>pom</packaging>
-    <version>8.1.5-0</version>
+    <version>8.1.6-0</version>
     <name>common</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -58,8 +58,8 @@
         <azure-security-keyvault-keys.version>4.10.7</azure-security-keyvault-keys.version>
         <httpclient5.version>5.4.4</httpclient5.version>
         <required.maven.version>3.2</required.maven.version>
-        <kafka.version>[8.1.5-0-ccs, 8.1.6-0-ccs)</kafka.version>
-        <ce.kafka.version>[8.1.5-0-ce, 8.1.6-0-ce)</ce.kafka.version>
+        <kafka.version>[8.1.6-0-ccs, 8.1.7-0-ccs)</kafka.version>
+        <ce.kafka.version>[8.1.6-0-ce, 8.1.7-0-ce)</ce.kafka.version>
         <easymock.version>5.6.0</easymock.version>
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
@@ -151,7 +151,7 @@
         <docker.pull-image>false</docker.pull-image>
         <docker.imagePullPolicy>IfNotPresent</docker.imagePullPolicy>
         <dependency.check.skip>true</dependency.check.skip>
-        <io.confluent.common.version>8.1.5-0</io.confluent.common.version>
+        <io.confluent.common.version>8.1.6-0</io.confluent.common.version>
         <!-- This is a version of the pom file that we install and deploy because
             the kafka and ce-kafka version ranges are resolved.
         -->
@@ -161,7 +161,7 @@
             resolving the version of ccs and ce kafka. This property should
             never be used any where else.
         -->
-        <confluent.version.range>[8.1.5-0, 8.1.6-0)</confluent.version.range>
+        <confluent.version.range>[8.1.6-0, 8.1.7-0)</confluent.version.range>
         <!-- This is the version range used by resolver-maven-plugin to resolve the
             version of ccs and ce-kafka. This allowed this property to be overridden
             through cmd lines.

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <mockito-all.version>1.10.19</mockito-all.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
         <hamcrest.version>1.3</hamcrest.version>
         <protobuf.version>4.34.0</protobuf.version>
         <powermock.version>2.0.9</powermock.version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.3-0</version>
+        <version>8.1.4-0</version>
     </parent>
 
     <properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.4</version>
     </parent>
 
     <properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5-0</version>
     </parent>
 
     <properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.4-0</version>
+        <version>8.1.5</version>
     </parent>
 
     <properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>common-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>8.1.5-0</version>
+        <version>8.1.6-0</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
## Summary
- Resolves the merge conflict blocking #1103 by merging origin/8.1.x into the pint-generated `pr_merge_from_8_0_x_to_8_1_x` branch.
- Conflict was in `pom.xml`'s `kafka.version`/`ce.kafka.version` properties (8.0.x's patch version vs 8.1.x's) plus the now-unused `easymock.version` property (already removed on 8.0.x in #1102, propagated forward here since it's still unreferenced on 8.1.x).

## Resolution
- Kept 8.1.x's own `kafka.version`/`ce.kafka.version` ranges (`8.1.6-0-ccs`/`8.1.6-0-ce`) rather than 8.0.x's, since these are release-branch-specific and shouldn't regress to 8.0.x's numbering.
- Dropped the `easymock.version` property, consistent with the already-clean removal of its corresponding `org.easymock:easymock` dependency entry.
- All other file changes (module `pom.xml` version bumps to `8.1.6-0`, `.semaphore/semaphore.yml`) merged automatically with no conflicts.

## Test plan
- [ ] Merge this into `pr_merge_from_8_0_x_to_8_1_x`, confirm PR #1103 shows no conflicts
- [ ] CI passes on `pr_merge_from_8_0_x_to_8_1_x`
- [ ] Follow #1103's own next-steps (merge commit into `8.1.x`, re-run `pint merge`)