### PR TITLE
CPBR-4090 | Upgrade exec-maven-plugin to 3.6.3 to fix create-licenses-for-docker NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,10 @@
         <kafka.version>[8.5.0-0-0-ccs, 8.5.1-0-0-ccs)</kafka.version>
         <ce.kafka.version>[8.5.0-0-0-ce, 8.5.1-0-0-ce)</ce.kafka.version>
         <easymock.version>5.7.0</easymock.version>
-        <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
-             running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
-        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <!-- https://github.com/mojohaus/exec-maven-plugin/issues/76 (running our LicenseFinder plugin in
+             create-licenses-for-docker breaks under 1.6.0's includePluginDependencies handling) is fixed
+             as of 3.1.0; do not downgrade below that. -->
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
         <spotbugs.version>4.10.4</spotbugs.version>
         <spotbugs.maven.plugin.version>4.10.4.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
         <azure-storage.version>12.35.1</azure-storage.version>
         <azure-security-keyvault-keys.version>4.11.2</azure-security-keyvault-keys.version>
         <httpclient5.version>5.6.4</httpclient5.version>
-        <required.maven.version>3.2</required.maven.version>
+        <!-- exec-maven-plugin 3.1.1+ requires Maven 3.6.3+; keep this in sync with exec-maven-plugin.version below -->
+        <required.maven.version>3.6.3</required.maven.version>
         <kafka.version>[8.5.0-0-0-ccs, 8.5.1-0-0-ccs)</kafka.version>
         <ce.kafka.version>[8.5.0-0-0-ce, 8.5.1-0-0-ce)</ce.kafka.version>
         <easymock.version>5.7.0</easymock.version>


### PR DESCRIPTION
## Summary
- `exec-maven-plugin.version` was recently auto-bumped from 1.5.0 to 1.6.0, despite a comment warning not to, breaking `create-licenses-for-docker` (and thus common-docker's `cp-base-java` build) with `Cannot invoke "java.util.List.iterator()" because "this.pluginDependencies" is null`.
- This is [mojohaus/exec-maven-plugin#76](https://github.com/mojohaus/exec-maven-plugin/issues/76): a regression introduced in 1.6.0 that breaks `includePluginDependencies=true` + `executableDependency` combined with a lifecycle-phase-bound execution — exactly how `create-licenses-for-docker` invokes our LicenseFinder plugin.
- The bug was fixed upstream in `3.1.0` and was never backported to any 1.x release, so pinning back to 1.5.0 (the previous workaround) only avoids the regression rather than fixing it. This bumps to the latest `3.6.3` instead, so the fix is permanent and we get all subsequent bug/security fixes too.
- Reviewed the 3.0.0/3.1.0+ release notes for anything relevant to our config (`includePluginDependencies`, `executableDependency`, `<argument>` handling, minimum Maven version) — nothing breaking found.
- **Follow-up fix (per review feedback):** exec-maven-plugin 3.1.1+ (including 3.6.3) requires Maven 3.6.3+, but the enforcer's `requireMavenVersion` rule was still only enforcing `required.maven.version` = `3.2`. That mismatch meant the enforcer would pass on an older Maven while `exec:java` itself could fail or misbehave, producing confusing errors disconnected from the real cause. Bumped `required.maven.version` to `3.6.3` to keep it in sync.

## Test plan
- [x] Built an isolated repro of the `create-licenses-for-docker` execution shape (`includeProjectDependencies=false`, `includePluginDependencies=true`, `executableDependency` on `io.confluent:licenses`, `mainClass=io.confluent.licenses.LicenseFinder`, bound to the `package` phase) against the real `io.confluent:licenses` artifact.
  - With `exec-maven-plugin` `1.6.0`: fails with the exact same `pluginDependencies is null` NPE seen in the reported CI failure.
  - With `exec-maven-plugin` `3.6.3`: `LicenseFinder` runs successfully end-to-end (`BUILD SUCCESS`, real `licenses.html`/`licenses`/`notices` output generated).
- [ ] CI green on this PR (exercises the real `create-licenses-for-docker` execution across `common`'s consumers)

CPBR-4090

🤖 Generated with [Claude Code](https://claude.com/claude-code)