### PR TITLE
Remove spotbugs.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,12 +293,6 @@
                 <artifactId>jaxb-api</artifactId>
                 <version>${jaxb.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-annotations</artifactId>
-                <version>4.10.4</version>
-                <scope>provided</scope>
-            </dependency>
             <!-- We fix the scala version to prevent downstream projects from bringing in
             different minor versions of Scala via different dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <!-- keep exec-maven-plugin on 1.5.0 until https://github.com/mojohaus/exec-maven-plugin/issues/76 is fixed
              running our LicenseFinder plugin in create-licenses-for-docker breaks when upgrading to 1.6.0 -->
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-        <spotbugs.version>4.10.4</spotbugs.version>
         <spotbugs.maven.plugin.version>4.10.4.0</spotbugs.maven.plugin.version>
         <java.version>11</java.version>
         <jackson.version>2.22.1</jackson.version>
@@ -297,7 +296,7 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>${spotbugs.version}</version>
+                <version>4.10.4</version>
                 <scope>provided</scope>
             </dependency>
             <!-- We fix the scala version to prevent downstream projects from bringing in
@@ -646,7 +645,7 @@
                       <dependency>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs</artifactId>
-                        <version>${spotbugs.version}</version>
+                        <version>4.10.4</version>
                       </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
## Summary
- BOM manages https://github.com/confluentinc/confluent-common-bom/blob/b0d1d1d54a2e14bf912fa4104159ce20d838fa8a/pom.xml#L412
- Cleaned up downstream repos that are using spotbugs.version property. 
- Removed `spotbugs.version` from `<properties>`
- Left `spotbugs.maven.plugin.version` untouched; only `spotbugs.version` was in scope.

## Test plan
- [ ] CI build passes (compiles, spotbugs analysis runs unchanged at 4.10.4)