### PR TITLE
Remove avro.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <properties>
         <!--jacoco prepare-agent needs argLine defined to set this variable. if we don't have a default set then maven gets angry.-->
         <argLine></argLine>
-        <avro.version>1.12.2</avro.version>
         <commons-io.version>2.20.0</commons-io.version>
         <confluent-common-bom.version>0.1.13</confluent-common-bom.version>
         <aws-java-sdk.version>1.12.797</aws-java-sdk.version>


### PR DESCRIPTION
## Summary
- `avro.version` is a pure pass-through property in `common`'s pom (not consumed internally, only inherited by downstream `common-parent` consumers).
- `confluent-common-bom` manages `org.apache.avro:avro` at the same value (`1.12.2`), but downstream migration isn't complete yet: 6 repos tracked, 0 merged, 4 open, 2 closed as pre-BOM.
- **Draft** — not ready to merge. Any downstream repo still relying on inheriting this property will break the next time it bumps its `common`/`common-parent` version, until its own migration PR lands. Opening now so it's ready; merge once downstream catches up (or the team decides it's fine to proceed).

## Test plan
- [ ] CI passes on this repo (no internal usage, so should be a no-op build-wise)
- [ ] Confirm downstream migration status before merging